### PR TITLE
config(dev): set DRIVE_ROOT_FOLDER_ID (CSC) + real admin/review URLs

### DIFF
--- a/cloudbuild/dev.yaml
+++ b/cloudbuild/dev.yaml
@@ -47,9 +47,21 @@ substitutions:
   _GEMINI_SECRET: gub-drive-sync-gemini-api-key-dev
   _MAILGUN_SECRET: gub-drive-sync-mailgun-api-key-dev
   _CLOUDSQL_INSTANCE: gub-platform
-  _DRIVE_ROOT_FOLDER_ID: ""
-  _GUB_ADMIN_BASE_URL: http://localhost:5173
-  _GUB_REVIEW_BASE_URL: ""
+  # "CSC" folder — the dev sync root the drive bot credential is scoped to.
+  # Setting it does two things (see src/drive/{discover,poll}.ts): enables
+  # new-entity discovery AND narrows the poll's change filter to this tree.
+  # If a poll ever logs changesReturned>0 with changesInScope=0 consistently,
+  # the credential can't see this folder — clear the value and investigate.
+  # Applied to the live job directly on 2026-08-13 (gcloud run jobs update);
+  # this substitution keeps the next cloudbuild deploy consistent with that.
+  _DRIVE_ROOT_FOLDER_ID: "1kW8WUNh14AONTI5k9CcypS9uMX3Bou0V"
+  # Real dev URLs (were localhost:5173 / empty — harmless while dev mail is
+  # console-only, but every review magic-link in the logs pointed at
+  # localhost). Review links prefer _GUB_REVIEW_BASE_URL (public, no IAP);
+  # admin URL is the fallback + used for non-review admin links.
+  # Also applied to the live job on 2026-08-13, same as the folder id.
+  _GUB_ADMIN_BASE_URL: https://gub-admin-dev-843516467880.us-central1.run.app
+  _GUB_REVIEW_BASE_URL: https://gub-review-dev-843516467880.us-central1.run.app
 
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## What

Three substitution fixes in `cloudbuild/dev.yaml` for the dev Cloud Run Job:

| Var | Was | Now |
|---|---|---|
| `_DRIVE_ROOT_FOLDER_ID` | `""` | `1kW8WUNh14AONTI5k9CcypS9uMX3Bou0V` ("CSC" — the dev sync root) |
| `_GUB_ADMIN_BASE_URL` | `http://localhost:5173` | `https://gub-admin-dev-…run.app` |
| `_GUB_REVIEW_BASE_URL` | `""` | `https://gub-review-dev-…run.app` |

None of these are secrets: the folder id is an identifier, not a credential (Drive access = bot OAuth + ACLs; the yaml's own comment already marked it "no secret"), and the Cloud Run URLs are non-sensitive by design (review uses single-use magic tokens, admin sits behind IAP). Real credentials in this file stay referenced by Secret Manager name only, unchanged.

## Why

- **Root folder** does two things (`src/drive/{discover,poll}.ts`): enables  new-entity discovery (a documented no-op while unset) and narrows the poll's change filter to the CSC tree (unset = "accept everything" dev-mode). Expect a one-time wave of "new account" proposals on the first full sync after this lands — every unlinked top-level folder under CSC.
- **URLs**: every review magic-link the job generated pointed at `http://localhost:5173/drive-review/<token>`. Invisible today only because dev mail is console-driver; a landmine for the day dev mail goes real. Review links now prefer gub-review (public, no IAP) per the code's intent.

## Why this file, and why now

The values are already applied to the running `gub-drive-sync-dev` job (`gcloud run jobs update`, 2026-08-13) — so this PR changes no runtime behavior. It makes them **durable**, and this yaml is the only place that can:

- Terraform deliberately does not manage Cloud Run services/jobs (it would fight CI over the image on every apply), so job env is outside its scope.
- The new GHA `Deploy` workflow is image-only (`jobs deploy --image`) and manual-only — it never sets env, and its own header names  `cloudbuild/<env>.yaml` as the config source of truth.

Without this merge the fix is temporary: `gub-drive-sync-trigger` is enabled on `^main$` and the deploy step uses `--set-env-vars`, which replaces the whole env set — so the next push to `main` silently reverts the folder id to `""` and the URLs to localhost.

## Rollback signal

If polls consistently log `changesReturned > 0` with `changesInScope = 0`, the bot credential can't see the CSC tree — revert with:

```bash
gcloud run jobs update gub-drive-sync-dev --region=us-central1 \   --remove-env-vars=DRIVE_ROOT_FOLDER_ID
```

…and clear the substitution here. (Also documented in the yaml comment.)

## Verification so far

A scheduler-triggered poll after the live update ran clean (`outcome: no_changes`, exit 0), and the in-flight chunked full sync finished successfully across 3 chunks (`full sync complete`, fresh page token persisted). Note the folder filter itself hasn't been exercised yet — there were zero Drive changes in the feed at the time.

## Context

Companion to the gcp-universal-backend Terraform migration PR: `drive-poll-dev` had been silently 404-ing daily since the May extraction; repairing it there is what surfaced this repo's config gaps.