### PR TITLE
feat: vision-first PDF extraction with text-layer fallback (C1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,18 @@ DRIVE_PROPOSAL_TTL_DAYS=14
 GEMINI_API_KEY=
 GEMINI_MAX_INPUT_CHARS=40000
 
+# ── Vision extraction (issue C1 / #34) ──────────────────────────────────────
+# PDFs go through Gemini document understanding first, falling back to the
+# text-layer parser (unpdf) on any gate or failure. Defaults shown; all
+# optional. DRIVE_VISION_MODEL empty → the stack's default Gemini model.
+DRIVE_VISION_ENABLED=true
+DRIVE_VISION_MODEL=
+# 14 MB raw — base64 inflates 4/3 and the API caps inline requests at 20 MB total.
+DRIVE_VISION_MAX_FILE_SIZE_BYTES=14680064
+DRIVE_VISION_MAX_PDF_PAGES=50
+DRIVE_VISION_MAX_OUTPUT_TOKENS=32768
+DRIVE_VISION_TIMEOUT_MS=180000
+
 # ── Notify (reviewer emails) ────────────────────────────────────────────────
 # Base URL of gub-review (public, no IAP). Notify embeds the magic-link as
 # ${GUB_REVIEW_BASE_URL}/drive-review/${reviewToken}. Falls back to

--- a/scripts/eval-vision-extraction.ts
+++ b/scripts/eval-vision-extraction.ts
@@ -1,0 +1,234 @@
+/**
+ * eval-vision-extraction.ts — C1 (#34) side-by-side eval: Gemini vision
+ * extraction vs the unpdf text-layer baseline, on ONE real account's PDFs.
+ *
+ * For each sampled PDF (freshest snapshot per fileId, spread across sizes):
+ *   1. download once
+ *   2. text-layer path (unpdf)  — timed
+ *   3. vision path (visionExtractPdf) — timed, token usage recorded
+ *   4. quality judge: one more vision call sees the PDF + BOTH transcripts
+ *      and scores each 0–10 on information completeness (text, tables,
+ *      charts/visuals) and structure fidelity
+ * Prints a markdown table (for the PR) plus totals.
+ *
+ * Usage:
+ *   npx tsx scripts/eval-vision-extraction.ts                 # list accounts by PDF count
+ *   npx tsx scripts/eval-vision-extraction.ts --account acme --limit 8 \
+ *     --price-in 0.30 --price-out 2.50                        # $/1M tokens
+ *
+ * Env: DATABASE_URL, GUB_BOT_OAUTH_CLIENT_ID/SECRET, and Gemini auth
+ * (GEMINI_USE_ENTERPRISE=true + GCP_PROJECT_ID, or GEMINI_API_KEY).
+ * Read-only against Drive; writes nothing to the DB.
+ */
+
+import { prisma } from '../src/prisma';
+import { downloadFileBuffer, getFileMetadata } from '../src/drive/client';
+import { visionExtractPdf, countPdfPages } from '../src/drive/extract-vision';
+import { defaultLlm, SchemaType, type ResponseSchema } from '../src/ai';
+import { config } from '../src/config';
+
+interface Args {
+  account: string | undefined;
+  limit: number;
+  priceIn: number; // $ per 1M input tokens
+  priceOut: number; // $ per 1M output tokens
+}
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2);
+  const get = (flag: string): string | undefined => {
+    const i = argv.indexOf(flag);
+    return i >= 0 ? argv[i + 1] : undefined;
+  };
+  return {
+    account: get('--account'),
+    limit: Number(get('--limit') ?? 8),
+    priceIn: Number(get('--price-in') ?? 0),
+    priceOut: Number(get('--price-out') ?? 0),
+  };
+}
+
+async function listAccounts(): Promise<void> {
+  const rows = await prisma.$queryRaw<Array<{ name: string; id: string; pdfs: bigint }>>`
+    select a.name, a.id, count(distinct s.file_id) as pdfs
+    from drive_file_snapshots s
+    join accounts a on a.id = s.account_id
+    where s.mime_type = 'application/pdf'
+    group by a.name, a.id
+    order by pdfs desc
+    limit 15`;
+  console.log('Accounts by distinct PDF count:');
+  for (const r of rows) console.log(`  ${String(r.pdfs).padStart(4)}  ${r.name}  (${r.id})`);
+}
+
+interface Sampled {
+  fileId: string;
+  name: string;
+  sizeBytes: number | null;
+}
+
+async function samplePdfs(accountNeedle: string, limit: number): Promise<Sampled[]> {
+  const account = await prisma.account.findFirst({
+    where: { name: { contains: accountNeedle, mode: 'insensitive' } },
+    select: { id: true, name: true },
+  });
+  if (!account) throw new Error(`no account matching "${accountNeedle}"`);
+  console.log(`Account: ${account.name} (${account.id})\n`);
+
+  const rows = await prisma.$queryRaw<Array<{ file_id: string; name: string; size_bytes: bigint | null }>>`
+    select distinct on (file_id) file_id, name, size_bytes
+    from drive_file_snapshots
+    where account_id = ${account.id}::uuid and mime_type = 'application/pdf'
+    order by file_id, scanned_at desc`;
+
+  // Vision-eligible only (the eval compares the two paths; over-cap files
+  // exercise the fallback, which the unit tests already pin).
+  const eligible = rows
+    .filter((r) => r.size_bytes !== null && Number(r.size_bytes) <= config.DRIVE_VISION_MAX_FILE_SIZE_BYTES)
+    .sort((a, b) => Number(a.size_bytes) - Number(b.size_bytes));
+  if (eligible.length === 0) throw new Error('no vision-eligible PDFs for this account');
+
+  // Even spread across the size range.
+  const picked: Sampled[] = [];
+  const step = Math.max(1, Math.floor(eligible.length / limit));
+  for (let i = 0; i < eligible.length && picked.length < limit; i += step) {
+    const r = eligible[i]!;
+    picked.push({ fileId: r.file_id, name: r.name, sizeBytes: r.size_bytes === null ? null : Number(r.size_bytes) });
+  }
+  return picked;
+}
+
+const JUDGE_SCHEMA: ResponseSchema = {
+  type: SchemaType.OBJECT,
+  properties: {
+    textLayerScore: { type: SchemaType.NUMBER },
+    visionScore: { type: SchemaType.NUMBER },
+    notes: { type: SchemaType.STRING },
+  },
+  required: ['textLayerScore', 'visionScore', 'notes'],
+};
+
+async function judge(
+  buf: Buffer,
+  textLayer: string,
+  vision: string,
+): Promise<{ textLayerScore: number; visionScore: number; notes: string }> {
+  const clip = (s: string) => (s.length > 12000 ? s.slice(0, 12000) + '\n…[clipped]' : s);
+  const res = await defaultLlm.complete({
+    model: config.DRIVE_VISION_MODEL || 'gemini-3.5-flash',
+    temperature: 0,
+    prompt: `The attached PDF was transcribed by two different extractors. Score EACH transcription 0-10 on how completely it captures the document's information: body text, tables, and content that only exists visually (charts, diagrams, designed layouts). Structure fidelity (section/page markers, reading order) counts. A transcription missing content that is clearly present in the PDF must lose points.
+
+=== TRANSCRIPTION A (text-layer) ===
+${clip(textLayer)}
+
+=== TRANSCRIPTION B (vision) ===
+${clip(vision)}`,
+    media: [{ mimeType: 'application/pdf', dataBase64: buf.toString('base64') }],
+    responseSchema: JUDGE_SCHEMA,
+    maxOutputTokens: 4096,
+    timeoutMs: config.DRIVE_VISION_TIMEOUT_MS,
+    tag: 'eval.vision_judge',
+  });
+  return JSON.parse(res.text) as { textLayerScore: number; visionScore: number; notes: string };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  if (!args.account) {
+    await listAccounts();
+    return;
+  }
+  const files = await samplePdfs(args.account, args.limit);
+  console.log(`Sampled ${files.length} vision-eligible PDFs.\n`);
+
+  const rows: string[] = [];
+  let totPromptTok = 0;
+  let totOutTok = 0;
+  let totThoughtTok = 0;
+
+  for (const f of files) {
+    const meta = await getFileMetadata(f.fileId);
+    if (!meta) {
+      console.log(`  SKIP (gone from Drive): ${f.name}`);
+      continue;
+    }
+    const buf = await downloadFileBuffer(f.fileId);
+    const pages = await countPdfPages(buf);
+
+    // Text-layer baseline (same code path as extract.ts's fallback).
+    const t0 = Date.now();
+    let textLayer = '';
+    let textErr: string | null = null;
+    try {
+      const { getDocumentProxy, extractText } = await import('unpdf');
+      const pdf = await getDocumentProxy(new Uint8Array(buf), { verbosity: 0 });
+      textLayer = (await extractText(pdf, { mergePages: true })).text.trim();
+    } catch (e) {
+      textErr = String(e).slice(0, 80);
+    }
+    const textMs = Date.now() - t0;
+
+    // Vision path.
+    const t1 = Date.now();
+    let vision = '';
+    let visionErr: string | null = null;
+    let usage: { promptTokens: number | null; outputTokens: number | null; thoughtsTokens: number | null } | undefined;
+    try {
+      const r = await visionExtractPdf(buf);
+      vision = r.text;
+      usage = r.usage;
+    } catch (e) {
+      visionErr = String(e).slice(0, 120);
+    }
+    const visionMs = Date.now() - t1;
+
+    totPromptTok += usage?.promptTokens ?? 0;
+    totOutTok += usage?.outputTokens ?? 0;
+    totThoughtTok += usage?.thoughtsTokens ?? 0;
+
+    // Quality judge (skipped when either side failed).
+    let scores = { textLayerScore: NaN, visionScore: NaN, notes: textErr ?? visionErr ?? '' };
+    if (!textErr && !visionErr) {
+      try {
+        scores = await judge(buf, textLayer, vision);
+      } catch (e) {
+        scores.notes = `judge failed: ${String(e).slice(0, 80)}`;
+      }
+    }
+
+    const outTokBillable = (usage?.outputTokens ?? 0) + (usage?.thoughtsTokens ?? 0);
+    const cost =
+      args.priceIn && usage?.promptTokens
+        ? (usage.promptTokens / 1e6) * args.priceIn + (outTokBillable / 1e6) * args.priceOut
+        : null;
+
+    rows.push(
+      `| ${f.name.slice(0, 40)} | ${pages ?? '?'} | ${((buf.length / 1024) | 0)} KB | ` +
+        `${textLayer.length} ch / ${textMs} ms | ` +
+        `${visionErr ? 'ERR' : vision.length + ' ch'} / ${(visionMs / 1000).toFixed(1)} s | ` +
+        `${usage?.promptTokens ?? '—'} / ${outTokBillable || '—'} | ` +
+        `${cost === null ? '—' : '$' + cost.toFixed(4)} | ` +
+        `${Number.isNaN(scores.textLayerScore) ? '—' : scores.textLayerScore} → ${Number.isNaN(scores.visionScore) ? '—' : scores.visionScore} | ` +
+        `${scores.notes.replace(/\|/g, '/').replace(/\n/g, ' ').slice(0, 110)} |`,
+    );
+    console.log(`  done: ${f.name} (${pages} pages, vision ${(visionMs / 1000).toFixed(1)}s)`);
+  }
+
+  console.log('\n| File | Pages | Size | Text-layer (chars/latency) | Vision (chars/latency) | Vision tokens in/out | Vision cost | Quality text→vision (0-10) | Judge notes |');
+  console.log('|---|---|---|---|---|---|---|---|---|');
+  for (const r of rows) console.log(r);
+  const totCost = args.priceIn
+    ? (totPromptTok / 1e6) * args.priceIn + ((totOutTok + totThoughtTok) / 1e6) * args.priceOut
+    : null;
+  console.log(
+    `\nTotals: prompt=${totPromptTok} output=${totOutTok} thoughts=${totThoughtTok} tokens` +
+      (totCost === null ? '' : `; est. cost $${totCost.toFixed(4)} (${rows.length} files)`),
+  );
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/ai/ai.types.ts
+++ b/src/ai/ai.types.ts
@@ -36,6 +36,22 @@ export interface LlmCompletionRequest {
    * thinkingBudget — set at most one.
    */
   thinkingLevel?: 'MINIMAL' | 'LOW' | 'MEDIUM' | 'HIGH';
+  /**
+   * Inline binary media (e.g. a PDF for Gemini document understanding).
+   * Each entry is sent as an inlineData Part AHEAD of the text prompt.
+   * The API caps the TOTAL request (prompt + base64-encoded media) at
+   * 20 MB — callers must enforce a lower cap on raw bytes, since base64
+   * inflates by 4/3. The mock driver ignores media entirely, so callers
+   * that need real content (vision extraction) must not treat a mock
+   * response as an extraction.
+   */
+  media?: Array<{ mimeType: string; dataBase64: string }>;
+  /**
+   * Per-request transport timeout in ms. Bounds slow multimodal calls
+   * (vision extraction of many-page PDFs) without changing the
+   * client-wide default for ordinary text completions.
+   */
+  timeoutMs?: number;
 }
 
 export interface LlmUsage {

--- a/src/ai/gemini.client.ts
+++ b/src/ai/gemini.client.ts
@@ -99,12 +99,23 @@ class GeminiLlmDriver implements LlmDriver {
   }
 
   async complete(req: LlmCompletionRequest): Promise<LlmCompletionResult> {
+    // Multimodal requests put the inlineData parts FIRST, then the text
+    // prompt — the order the document-understanding docs use. Text-only
+    // requests keep the plain-string shape (identical wire behavior).
+    const contents = req.media?.length
+      ? [
+          ...req.media.map((m) => ({
+            inlineData: { data: m.dataBase64, mimeType: m.mimeType },
+          })),
+          req.prompt,
+        ]
+      : req.prompt;
     let lastErr: unknown;
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
       try {
         const res = await this.client.models.generateContent({
           model: req.model,
-          contents: req.prompt,
+          contents,
           config: {
             temperature: req.temperature,
             ...(req.responseSchema
@@ -116,6 +127,12 @@ class GeminiLlmDriver implements LlmDriver {
               : req.thinkingLevel !== undefined
                 ? { thinkingConfig: { thinkingLevel: req.thinkingLevel as ThinkingLevel } }
                 : {}),
+            // Per-request httpOptions REPLACE the client-level ones, so
+            // re-pin retryOptions.attempts=1 — otherwise the SDK's own
+            // retry would stack on top of this loop for these requests.
+            ...(req.timeoutMs
+              ? { httpOptions: { timeout: req.timeoutMs, retryOptions: { attempts: 1 } } }
+              : {}),
           },
         });
         const text = res.text ?? '';

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,6 +54,44 @@ const EnvSchema = z.object({
    */
   GEMINI_LOCATION: z.string().default('global'),
   GEMINI_MAX_INPUT_CHARS: z.string().default('40000').transform(Number),
+
+  // ── Vision extraction (issue C1 / #34) ──────────────────────────────────
+  // PDFs go through Gemini document understanding ("vision") first, with
+  // automatic fallback to the text-layer parser (unpdf) on ANY vision
+  // failure. Docs/Sheets/Slides are untouched (native APIs beat OCR).
+  /** Kill switch: 'false' routes all PDFs straight to the text-layer path. */
+  DRIVE_VISION_ENABLED: z
+    .string()
+    .default('true')
+    .transform((v) => v === 'true'),
+  /** Override the vision model. Empty/unset → DEFAULT_GEMINI_MODEL. */
+  DRIVE_VISION_MODEL: z.string().optional(),
+  /**
+   * Raw-byte cap for the vision path (NOT the download cap — that stays
+   * DRIVE_MAX_FILE_SIZE_BYTES). The API rejects inline requests over
+   * 20 MB TOTAL and base64 inflates bytes by 4/3, so 14 MB raw ≈ 18.7 MB
+   * encoded + prompt headroom. Bigger PDFs fall back to the text path.
+   */
+  DRIVE_VISION_MAX_FILE_SIZE_BYTES: z.string().default('14680064').transform(Number),
+  /**
+   * Page cap for the vision path (API hard limit is 1000 pages; each page
+   * costs ~258 input tokens + output scales with density). Above the cap
+   * we fall back to the text path — long PDFs are overwhelmingly
+   * text-layer documents anyway; vision's win is dense visual decks.
+   */
+  DRIVE_VISION_MAX_PDF_PAGES: z.string().default('50').transform(Number),
+  /**
+   * Output cap for the vision transcription. gemini-3.5-flash thinking
+   * tokens count against this cap (see campaign-cluster-detector.ts for
+   * the truncation failure mode) — keep it generous; the model max is 65k.
+   */
+  DRIVE_VISION_MAX_OUTPUT_TOKENS: z.string().default('32768').transform(Number),
+  /**
+   * Per-file transport timeout for the vision call. A hung multimodal
+   * request must not stall the whole scan — on timeout we fall back to
+   * the text path like any other vision failure.
+   */
+  DRIVE_VISION_TIMEOUT_MS: z.string().default('180000').transform(Number),
   /**
    * Worker-pool concurrency for the per-entity distill+synth+write loop
    * inside processBatch. Each entity owns a discrete status_markdown blob

--- a/src/drive/__tests__/extract.test.ts
+++ b/src/drive/__tests__/extract.test.ts
@@ -56,7 +56,7 @@ vi.mock('googleapis', () => ({
   },
 }));
 
-vi.mock('../workspace', () => ({
+vi.mock('../../workspace', () => ({
   buildBotOAuthClient: buildBotOAuthClientMock,
 }));
 
@@ -75,15 +75,15 @@ const { mockConfig, CONFIG_DEFAULTS } = vi.hoisted(() => {
   return { mockConfig: { ...CONFIG_DEFAULTS }, CONFIG_DEFAULTS };
 });
 
-vi.mock('../config', () => ({
+vi.mock('../../config', () => ({
   config: mockConfig,
 }));
 
-vi.mock('../logger', () => ({
+vi.mock('../../logger', () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-vi.mock('./client', () => ({
+vi.mock('../client', () => ({
   downloadFileBuffer: vi.fn(),
 }));
 
@@ -94,9 +94,9 @@ const { llmComplete, llmDriver } = vi.hoisted(() => {
   return { llmComplete, llmDriver: { name: 'gemini', complete: llmComplete } };
 });
 
-// Mocking '../ai' also keeps its prisma-importing preset service out of
+// Mocking '../../ai' also keeps its prisma-importing preset service out of
 // the unit suite (hermeticity — see the CI note in the repo history).
-vi.mock('../ai', () => ({
+vi.mock('../../ai', () => ({
   defaultLlm: llmDriver,
   DEFAULT_GEMINI_MODEL: 'gemini-3.5-flash',
 }));
@@ -166,9 +166,9 @@ import {
   extractGoogleDoc,
   extractGoogleSlides,
   extractGoogleSheets,
-} from './extract';
-import { downloadFileBuffer } from './client';
-import type { TraversedFile } from './types';
+} from '../extract';
+import { downloadFileBuffer } from '../client';
+import type { TraversedFile } from '../types';
 
 /** Minimal TraversedFile factory for the dispatch/vision/lockstep tests. */
 function makeFile(overrides: Partial<TraversedFile>): TraversedFile {

--- a/src/drive/__tests__/retry.test.ts
+++ b/src/drive/__tests__/retry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { isTransientTransportError, withTransientRetry } from './retry';
+import { isTransientTransportError, withTransientRetry } from '../retry';
 
 describe('isTransientTransportError', () => {
   it('accepts 5xx from Google, however the status is shaped', () => {

--- a/src/drive/extract-vision.ts
+++ b/src/drive/extract-vision.ts
@@ -1,0 +1,147 @@
+/**
+ * extract-vision.ts — Gemini document-understanding ("vision") extraction
+ * for PDFs (issue C1 / #34).
+ *
+ * The text-layer parser (unpdf) reads only the PDF's embedded text: it
+ * loses layout, charts, and everything in image-set decks (a designed
+ * pitch deck exported to PDF often carries most of its content as
+ * rendered artwork). Gemini multimodal reads the rendered pages, so it
+ * transcribes visual decks the text layer can't.
+ *
+ * Contract (verified against the document-understanding docs, 2026-08):
+ *   - gemini-3.5-flash accepts PDFs as inlineData parts on
+ *     generateContent; the TOTAL request is capped at 20 MB and 1000
+ *     pages; each page costs ~258 image tokens on top of native text.
+ *   - Only PDF gets this treatment. PPTX is NOT an accepted document
+ *     mime for inline understanding — decks benefit when they are PDF
+ *     exports (the common agency case). Google Slides stays on the
+ *     native Slides API (structured text beats OCR; see extract.ts).
+ *
+ * Failure posture: a vision failure must NEVER fail the scan or drop a
+ * file. Every gate and error here returns null, and extract.ts falls
+ * back to the text-layer path. There is no `vision_failed` skip reason
+ * by design — vision failing is a downgrade, not a skip.
+ *
+ * Output contract: the SAME flat marked-up text the Google-native
+ * walkers emit (`# Title`, `## <section>` markers, tab-separated table
+ * rows) so downstream interpret.ts consumes it unchanged.
+ */
+
+import { config } from '../config';
+import { logger } from '../logger';
+import { defaultLlm, DEFAULT_GEMINI_MODEL } from '../ai';
+import type { LlmUsage } from '../ai';
+import type { TraversedFile } from './types';
+
+/**
+ * Mirrors the walkers' marker contract: `#` title, `##` per-page
+ * sections, tab-separated tables — flat text throughout. Bracketed
+ * one-line descriptions surface chart/image content that a text-layer
+ * extraction would silently drop.
+ */
+const VISION_PROMPT = `You are a document transcription engine. Transcribe the attached PDF into flat, structured plain text.
+
+Rules:
+- If a document title is evident, emit "# <title>" as the first line.
+- For each page emit a "## Page N" heading, then that page's content in natural reading order.
+- Preserve headings, paragraphs, and lists as plain text lines.
+- Render tables as tab-separated cells, one row per line.
+- For charts, diagrams, and meaningful images, add a one-line description in square brackets, e.g. [Chart: monthly revenue by region, peaks in March].
+- Transcribe ALL legible text, but emit boilerplate that recurs on every page (confidentiality footers, page numbers) at most once.
+- Output the transcription only — no preamble, no commentary, no code fences.`;
+
+export interface VisionExtractionResult {
+  text: string;
+  model: string;
+  usage?: LlmUsage;
+}
+
+/**
+ * Count pages via the text-layer parser. Returns null when the parser
+ * can't open the file — which deliberately does NOT disqualify vision:
+ * scanned/exotic PDFs that unpdf chokes on are exactly where vision can
+ * still succeed (the 1000-page API limit backstops us; an over-limit
+ * request errors and falls back like any other vision failure).
+ */
+export async function countPdfPages(buf: Buffer): Promise<number | null> {
+  try {
+    const { getDocumentProxy } = await import('unpdf');
+    const pdf = await getDocumentProxy(new Uint8Array(buf), { verbosity: 0 });
+    return pdf.numPages;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The raw vision call — no gating, throws on error. Exposed separately
+ * so the eval script can measure it (latency + token usage) without the
+ * fallback semantics swallowing failures.
+ */
+export async function visionExtractPdf(buf: Buffer): Promise<VisionExtractionResult> {
+  const model = config.DRIVE_VISION_MODEL || DEFAULT_GEMINI_MODEL;
+  const result = await defaultLlm.complete({
+    model,
+    temperature: 0,
+    prompt: VISION_PROMPT,
+    media: [{ mimeType: 'application/pdf', dataBase64: buf.toString('base64') }],
+    maxOutputTokens: config.DRIVE_VISION_MAX_OUTPUT_TOKENS,
+    // Transcription doesn't need reasoning; thinking tokens count
+    // against maxOutputTokens AND add latency. Bump if quality suffers.
+    thinkingLevel: 'MINIMAL',
+    timeoutMs: config.DRIVE_VISION_TIMEOUT_MS,
+    tag: 'drive.vision_extraction.v1',
+  });
+  return { text: result.text.trim(), model, ...(result.usage ? { usage: result.usage } : {}) };
+}
+
+/**
+ * Vision extraction with all gates applied. Returns the transcribed
+ * text, or null for "use the text-layer path instead" — on gating
+ * (disabled, mock driver, size/page caps) and on ANY error, including
+ * an empty transcription (anomalous for a non-empty PDF; the text layer
+ * decides whether the file is genuinely empty).
+ */
+export async function tryVisionPdfExtraction(
+  file: Pick<TraversedFile, 'id' | 'name'>,
+  buf: Buffer,
+): Promise<string | null> {
+  if (!config.DRIVE_VISION_ENABLED) return null;
+  // The mock driver returns a schema-shaped stub, not a transcription —
+  // storing it as extracted text would poison the pipeline in dev.
+  if (defaultLlm.name === 'mock') return null;
+  if (buf.length > config.DRIVE_VISION_MAX_FILE_SIZE_BYTES) {
+    logger.debug(
+      { fileId: file.id, name: file.name, sizeBytes: buf.length },
+      '[drive.vision] over vision size cap — using text-layer path',
+    );
+    return null;
+  }
+  const pageCount = await countPdfPages(buf);
+  if (pageCount !== null && pageCount > config.DRIVE_VISION_MAX_PDF_PAGES) {
+    logger.debug(
+      { fileId: file.id, name: file.name, pageCount },
+      '[drive.vision] over vision page cap — using text-layer path',
+    );
+    return null;
+  }
+
+  try {
+    const { text } = await visionExtractPdf(buf);
+    if (!text) {
+      logger.warn(
+        { fileId: file.id, name: file.name, pageCount },
+        '[drive.vision] vision_failed: empty transcription — falling back to text-layer path',
+      );
+      return null;
+    }
+    return text;
+  } catch (err) {
+    // Transient faults were already retried inside the LLM driver.
+    logger.warn(
+      { err, fileId: file.id, name: file.name, sizeBytes: buf.length, pageCount },
+      '[drive.vision] vision_failed — falling back to text-layer path',
+    );
+    return null;
+  }
+}

--- a/src/drive/extract.test.ts
+++ b/src/drive/extract.test.ts
@@ -1,7 +1,7 @@
 /**
- * Unit tests for the per-MIME walkers in drive.extract.ts.
+ * Unit tests for drive.extract.ts.
  *
- * Each walker is tested against representative API response shapes (the
+ * Walkers: each is tested against representative API response shapes (the
  * structural variations that matter — paragraph + table + nested toc for
  * Docs, slide + speaker notes + table for Slides, multi-sheet workbook for
  * Sheets). We don't test the integration with the real Google APIs here;
@@ -12,6 +12,16 @@
  *     (titles, slide numbers, sheet names, speaker-notes)
  *   - Empty/missing fields don't crash the walker
  *   - Tables flatten predictably (tab-separated cells, newline-separated rows)
+ *
+ * Vision path (issue C1): the PDF branch goes vision-first with automatic
+ * fallback to the text-layer parser. We pin:
+ *   - vision success → extractor='vision'
+ *   - EVERY vision gate/failure (error, empty output, size/page caps,
+ *     disabled, mock LLM driver) → silent fallback to extractor='pdf',
+ *     never a throw, never a skip
+ *   - predictExtractionSkip ↔ extractText lockstep: across the whole MIME
+ *     matrix, a predicted skip is returned verbatim by extractText and a
+ *     predicted null extracts ok — the vision branch must stay skip-neutral
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -50,8 +60,23 @@ vi.mock('../workspace', () => ({
   buildBotOAuthClient: buildBotOAuthClientMock,
 }));
 
+// Mutable config so vision-gate tests can flip knobs per-test; beforeEach
+// restores the defaults. Shared by extract.ts AND extract-vision.ts.
+const { mockConfig, CONFIG_DEFAULTS } = vi.hoisted(() => {
+  const CONFIG_DEFAULTS = {
+    DRIVE_MAX_FILE_SIZE_BYTES: 26214400,
+    DRIVE_VISION_ENABLED: true,
+    DRIVE_VISION_MODEL: undefined as string | undefined,
+    DRIVE_VISION_MAX_FILE_SIZE_BYTES: 14680064,
+    DRIVE_VISION_MAX_PDF_PAGES: 50,
+    DRIVE_VISION_MAX_OUTPUT_TOKENS: 32768,
+    DRIVE_VISION_TIMEOUT_MS: 180000,
+  };
+  return { mockConfig: { ...CONFIG_DEFAULTS }, CONFIG_DEFAULTS };
+});
+
 vi.mock('../config', () => ({
-  config: { DRIVE_MAX_FILE_SIZE_BYTES: 26214400 },
+  config: mockConfig,
 }));
 
 vi.mock('../logger', () => ({
@@ -62,7 +87,48 @@ vi.mock('./client', () => ({
   downloadFileBuffer: vi.fn(),
 }));
 
+// LLM driver mock (vision path). Mutable `name` lets the mock-driver
+// gate test flip it to 'mock'; beforeEach restores 'gemini'.
+const { llmComplete, llmDriver } = vi.hoisted(() => {
+  const llmComplete = vi.fn();
+  return { llmComplete, llmDriver: { name: 'gemini', complete: llmComplete } };
+});
+
+// Mocking '../ai' also keeps its prisma-importing preset service out of
+// the unit suite (hermeticity — see the CI note in the repo history).
+vi.mock('../ai', () => ({
+  defaultLlm: llmDriver,
+  DEFAULT_GEMINI_MODEL: 'gemini-3.5-flash',
+}));
+
+// Binary parsers, mocked so extractText's non-Google branches run without
+// real parsing. unpdf serves double duty: page count for the vision gate
+// AND the text-layer fallback.
+const { unpdfGetDocumentProxy, unpdfExtractText, officeParse, mammothExtract } = vi.hoisted(
+  () => ({
+    unpdfGetDocumentProxy: vi.fn(),
+    unpdfExtractText: vi.fn(),
+    officeParse: vi.fn(),
+    mammothExtract: vi.fn(),
+  }),
+);
+
+vi.mock('unpdf', () => ({
+  getDocumentProxy: unpdfGetDocumentProxy,
+  extractText: unpdfExtractText,
+}));
+
+vi.mock('officeparser', () => ({
+  parseOfficeAsync: officeParse,
+}));
+
+vi.mock('mammoth', () => ({
+  default: { extractRawText: mammothExtract },
+}));
+
 beforeEach(() => {
+  Object.assign(mockConfig, CONFIG_DEFAULTS);
+  llmDriver.name = 'gemini';
   buildBotOAuthClientMock.mockReset();
   buildBotOAuthClientMock.mockResolvedValue({ /* dummy auth client */ });
   docsGet.mockReset();
@@ -74,13 +140,51 @@ beforeEach(() => {
   googleMock.sheets.mockReturnValue({
     spreadsheets: { get: sheetsGet, values: { batchGet: sheetsBatchGet } },
   });
+
+  // Happy-path defaults for the binary branches; individual tests override.
+  vi.mocked(downloadFileBuffer).mockReset();
+  vi.mocked(downloadFileBuffer).mockResolvedValue(Buffer.from('%PDF-1.4 fake bytes'));
+  llmComplete.mockReset();
+  llmComplete.mockResolvedValue({
+    text: '# Vision Doc\n\n## Page 1\nvision transcription',
+    driver: 'gemini',
+    model: 'gemini-3.5-flash',
+  });
+  unpdfGetDocumentProxy.mockReset();
+  unpdfGetDocumentProxy.mockResolvedValue({ numPages: 3 });
+  unpdfExtractText.mockReset();
+  unpdfExtractText.mockResolvedValue({ text: 'text-layer extraction' });
+  officeParse.mockReset();
+  officeParse.mockResolvedValue('pptx text');
+  mammothExtract.mockReset();
+  mammothExtract.mockResolvedValue({ value: 'docx text' });
 });
 
 import {
+  extractText,
+  predictExtractionSkip,
   extractGoogleDoc,
   extractGoogleSlides,
   extractGoogleSheets,
 } from './extract';
+import { downloadFileBuffer } from './client';
+import type { TraversedFile } from './types';
+
+/** Minimal TraversedFile factory for the dispatch/vision/lockstep tests. */
+function makeFile(overrides: Partial<TraversedFile>): TraversedFile {
+  return {
+    id: 'file-1',
+    name: 'file.pdf',
+    mimeType: 'application/pdf',
+    path: 'Acme / Q3 / file.pdf',
+    modifiedTime: null,
+    modifiedByEmail: null,
+    createdTime: null,
+    size: 1024,
+    isFolder: false,
+    ...overrides,
+  };
+}
 
 // ── Google Docs walker ──────────────────────────────────────────────────────
 
@@ -394,4 +498,203 @@ describe('extractGoogleSheets', () => {
     expect(text).toContain('## Sheet: Sheet1');
     // No rows should appear, but no crash either.
   });
+});
+
+// ── PDF vision path (issue C1) ──────────────────────────────────────────────
+
+describe('extractText PDF vision path', () => {
+  const pdfFile = () => makeFile({ mimeType: 'application/pdf' });
+
+  it('extracts via vision on the happy path (extractor=vision)', async () => {
+    const outcome = await extractText(pdfFile());
+    expect(outcome).toMatchObject({
+      kind: 'ok',
+      extractor: 'vision',
+      text: '# Vision Doc\n\n## Page 1\nvision transcription',
+    });
+    expect((outcome as { contentHash: string }).contentHash).toMatch(/^[0-9a-f]{32}$/);
+    // The call carried the PDF as inline base64 document data with the
+    // caps + minimal thinking, per the C1 contract.
+    expect(llmComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'gemini-3.5-flash',
+        temperature: 0,
+        media: [
+          expect.objectContaining({
+            mimeType: 'application/pdf',
+            dataBase64: Buffer.from('%PDF-1.4 fake bytes').toString('base64'),
+          }),
+        ],
+        maxOutputTokens: 32768,
+        thinkingLevel: 'MINIMAL',
+        timeoutMs: 180000,
+      }),
+    );
+  });
+
+  it('falls back to the text-layer path when the vision call throws', async () => {
+    llmComplete.mockRejectedValue(new Error('503 model overloaded'));
+    const outcome = await extractText(pdfFile());
+    expect(outcome).toMatchObject({
+      kind: 'ok',
+      extractor: 'pdf',
+      text: 'text-layer extraction',
+    });
+  });
+
+  it('falls back when vision returns an empty transcription', async () => {
+    llmComplete.mockResolvedValue({ text: '   \n', driver: 'gemini', model: 'm' });
+    const outcome = await extractText(pdfFile());
+    expect(outcome).toMatchObject({ kind: 'ok', extractor: 'pdf' });
+  });
+
+  it('skips vision above the vision size cap but still extracts text', async () => {
+    mockConfig.DRIVE_VISION_MAX_FILE_SIZE_BYTES = 4; // smaller than the fake buffer
+    const outcome = await extractText(pdfFile());
+    expect(outcome).toMatchObject({ kind: 'ok', extractor: 'pdf' });
+    expect(llmComplete).not.toHaveBeenCalled();
+  });
+
+  it('skips vision above the page cap but still extracts text', async () => {
+    unpdfGetDocumentProxy.mockResolvedValue({ numPages: 51 });
+    const outcome = await extractText(pdfFile());
+    expect(outcome).toMatchObject({ kind: 'ok', extractor: 'pdf' });
+    expect(llmComplete).not.toHaveBeenCalled();
+  });
+
+  it('still tries vision when the page count is unknowable (text parser choked)', async () => {
+    // A PDF unpdf can't open is exactly where vision may still succeed.
+    unpdfGetDocumentProxy.mockRejectedValue(new Error('bad xref'));
+    const outcome = await extractText(pdfFile());
+    expect(outcome).toMatchObject({ kind: 'ok', extractor: 'vision' });
+  });
+
+  it('skips vision when DRIVE_VISION_ENABLED=false', async () => {
+    mockConfig.DRIVE_VISION_ENABLED = false;
+    const outcome = await extractText(pdfFile());
+    expect(outcome).toMatchObject({ kind: 'ok', extractor: 'pdf' });
+    expect(llmComplete).not.toHaveBeenCalled();
+  });
+
+  it('skips vision under the mock LLM driver (stub output must not become "text")', async () => {
+    llmDriver.name = 'mock';
+    const outcome = await extractText(pdfFile());
+    expect(outcome).toMatchObject({ kind: 'ok', extractor: 'pdf' });
+    expect(llmComplete).not.toHaveBeenCalled();
+  });
+
+  it('propagates the text-layer error when vision fails AND the fallback fails', async () => {
+    // A vision failure must never fail the scan on its own — but when the
+    // fallback also fails, that's a genuine extraction failure and keeps
+    // the existing throw-to-sync behavior.
+    llmComplete.mockRejectedValue(new Error('vision down'));
+    unpdfGetDocumentProxy.mockRejectedValue(new Error('bad xref'));
+    await expect(extractText(pdfFile())).rejects.toThrow('bad xref');
+  });
+});
+
+// ── predictExtractionSkip ↔ extractText lockstep ────────────────────────────
+// The two functions walk one decision tree; this matrix pins that a
+// predicted skip is returned VERBATIM by extractText and a predicted null
+// really extracts. The vision branch must stay skip-neutral: PDFs predict
+// null whether vision or the text layer ends up producing the text.
+
+describe('predictExtractionSkip ↔ extractText lockstep', () => {
+  const DOCX_MIME =
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+  const PPTX_MIME =
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+
+  const matrix: Array<{ label: string; file: TraversedFile; setup?: () => void }> = [
+    { label: 'folder', file: makeFile({ isFolder: true, mimeType: 'application/vnd.google-apps.folder' }) },
+    { label: 'unsupported mime (image/png)', file: makeFile({ mimeType: 'image/png' }) },
+    { label: 'PDF over the download cap', file: makeFile({ size: 26214401 }) },
+    { label: 'PDF within caps (vision on)', file: makeFile({}) },
+    {
+      label: 'PDF within caps (vision off)',
+      file: makeFile({}),
+      setup: () => {
+        mockConfig.DRIVE_VISION_ENABLED = false;
+      },
+    },
+    {
+      label: 'PDF under download cap but over vision cap',
+      file: makeFile({}),
+      setup: () => {
+        mockConfig.DRIVE_VISION_MAX_FILE_SIZE_BYTES = 4;
+      },
+    },
+    { label: 'DOCX', file: makeFile({ mimeType: DOCX_MIME, name: 'f.docx' }) },
+    { label: 'PPTX', file: makeFile({ mimeType: PPTX_MIME, name: 'f.pptx' }) },
+    { label: 'text/plain', file: makeFile({ mimeType: 'text/plain', name: 'f.txt' }) },
+    { label: 'text/plain over the download cap', file: makeFile({ mimeType: 'text/plain', size: 26214401 }) },
+    {
+      label: 'Google Doc',
+      file: makeFile({ mimeType: 'application/vnd.google-apps.document' }),
+      setup: () => docsGet.mockResolvedValue({ data: { title: 'Doc', body: { content: [] } } }),
+    },
+    {
+      label: 'Google Slides',
+      file: makeFile({ mimeType: 'application/vnd.google-apps.presentation' }),
+      setup: () => presentationsGet.mockResolvedValue({ data: { title: 'Deck', slides: [] } }),
+    },
+    {
+      label: 'Google Sheet',
+      file: makeFile({ mimeType: 'application/vnd.google-apps.spreadsheet' }),
+      setup: () =>
+        sheetsGet.mockResolvedValue({
+          data: { properties: { title: 'WB' }, sheets: [{ properties: { title: 'S1' } }] },
+        }) &&
+        sheetsBatchGet.mockResolvedValue({
+          data: { valueRanges: [{ range: 'S1!A1:B2', values: [['x']] }] },
+        }),
+    },
+    {
+      label: 'shortcut without resolved target',
+      file: makeFile({ mimeType: 'application/vnd.google-apps.shortcut' }),
+    },
+    {
+      label: 'shortcut to a folder',
+      file: makeFile({
+        mimeType: 'application/vnd.google-apps.shortcut',
+        shortcutTarget: { id: 't1', mimeType: 'application/vnd.google-apps.folder' },
+      }),
+    },
+    {
+      label: 'shortcut chain',
+      file: makeFile({
+        mimeType: 'application/vnd.google-apps.shortcut',
+        shortcutTarget: { id: 't1', mimeType: 'application/vnd.google-apps.shortcut' },
+      }),
+    },
+    {
+      label: 'shortcut to PDF (unverifiable size)',
+      file: makeFile({
+        mimeType: 'application/vnd.google-apps.shortcut',
+        shortcutTarget: { id: 't1', mimeType: 'application/pdf' },
+      }),
+    },
+    {
+      label: 'shortcut to Google Doc',
+      file: makeFile({
+        mimeType: 'application/vnd.google-apps.shortcut',
+        shortcutTarget: { id: 't1', mimeType: 'application/vnd.google-apps.document' },
+      }),
+      setup: () => docsGet.mockResolvedValue({ data: { title: 'Doc', body: { content: [] } } }),
+    },
+  ];
+
+  for (const { label, file, setup } of matrix) {
+    it(`agrees on ${label}`, async () => {
+      setup?.();
+      const predicted = predictExtractionSkip(file);
+      const actual = await extractText(file);
+      if (predicted) {
+        // Predicted skips must be returned verbatim — same reason AND detail.
+        expect(actual).toEqual(predicted);
+      } else {
+        expect(actual.kind).toBe('ok');
+      }
+    });
+  }
 });

--- a/src/drive/extract.ts
+++ b/src/drive/extract.ts
@@ -18,7 +18,10 @@
  *                        values.batchGet                 (extractor='gsheet')
  *
  *   Binary:
- *     - application/pdf                     → pdf-parse           (extractor='pdf')
+ *     - application/pdf → Gemini document understanding (extractor='vision'),
+ *       with automatic fallback to the text-layer parser unpdf
+ *       (extractor='pdf') on any vision gate or failure — see
+ *       extract-vision.ts for the gates and the failure posture
  *     - application/vnd.openxmlformats-…wordprocessingml.document  → mammoth (.docx)
  *     - text/* (plaintext, markdown, csv, etc.) → direct download (extractor='plaintext')
  *
@@ -41,6 +44,7 @@ import {
 import { config } from '../config';
 import { logger } from '../logger';
 import { downloadFileBuffer } from './client';
+import { tryVisionPdfExtraction } from './extract-vision';
 import { buildBotOAuthClient } from '../workspace';
 import type { ExtractionOutcome, ExtractionSkip, TraversedFile } from './types';
 
@@ -180,6 +184,12 @@ export function predictExtractionSkip(file: TraversedFile): ExtractionSkip | nul
       return null;
 
     // Binary download paths share the same size guard.
+    // NOTE (C1 lockstep): the vision branch in extractText's PDF case is
+    // deliberately absent here — it is skip-NEUTRAL. Vision gates and
+    // failures fall back to the text-layer path; they never produce a
+    // skip, so the predictor's PDF answer is unchanged. If a future
+    // change makes vision produce a skip outcome, it MUST be mirrored
+    // here (the lockstep test in extract.test.ts pins the agreement).
     case MIME.PDF:
     case MIME.DOCX:
     case MIME.PPTX: {
@@ -251,6 +261,16 @@ export async function extractText(file: TraversedFile): Promise<ExtractionOutcom
       // ── Binary downloads: size cap already checked in predictExtractionSkip.
       case MIME.PDF: {
         const buf = await downloadFileBuffer(effectiveFile.id);
+        // Vision-first (issue C1): Gemini document understanding reads
+        // layout, charts, and image-set decks the text layer can't.
+        // Every gate and failure inside tryVisionPdfExtraction returns
+        // null and lands on the text-layer path below — the vision
+        // branch never skips and never throws, which is what keeps
+        // predictExtractionSkip's decision tree untouched (the
+        // predictor's PDF answer is identical whether vision or the
+        // text layer ends up producing the text).
+        const visionText = await tryVisionPdfExtraction(effectiveFile, buf);
+        if (visionText !== null) return ok(visionText, 'vision');
         // Import lazily to keep the parser off the module init path.
         //
         // `unpdf` is a thin modern wrapper over `pdfjs-dist`'s legacy
@@ -284,9 +304,14 @@ export async function extractText(file: TraversedFile): Promise<ExtractionOutcom
         // Import lazily to keep officeparser off the module init path —
         // it has a heavy zlib/xml unpack chain we'd rather defer.
         // officeparser flattens to plain text; slide boundaries and
-        // speaker notes are mostly preserved as runs of lines. For
-        // richer visual understanding (charts/photos/layout), see the
-        // future "rich pipeline" plan in docs/status-markdown-plan.md.
+        // speaker notes are mostly preserved as runs of lines.
+        //
+        // PPTX does NOT get the vision path (C1): Gemini inline document
+        // understanding accepts PDF only — PPTX would need a PDF
+        // conversion step first. Decks benefit from vision when they're
+        // PDF exports (the common agency case, covered above). For a
+        // PPTX conversion pipeline see the future "rich pipeline" plan
+        // in docs/status-markdown-plan.md.
         const { parseOfficeAsync } = await import('officeparser');
         const text = await parseOfficeAsync(buf);
         return ok(text, 'pptx');

--- a/src/drive/extract.ts
+++ b/src/drive/extract.ts
@@ -189,7 +189,7 @@ export function predictExtractionSkip(file: TraversedFile): ExtractionSkip | nul
     // failures fall back to the text-layer path; they never produce a
     // skip, so the predictor's PDF answer is unchanged. If a future
     // change makes vision produce a skip outcome, it MUST be mirrored
-    // here (the lockstep test in extract.test.ts pins the agreement).
+    // here (the lockstep test in __tests__/extract.test.ts pins the agreement).
     case MIME.PDF:
     case MIME.DOCX:
     case MIME.PPTX: {

--- a/src/scan/__tests__/note-marker.test.ts
+++ b/src/scan/__tests__/note-marker.test.ts
@@ -3,7 +3,7 @@ import {
   hasNewCandidateMarker,
   newCandidateMarker,
   stripNewCandidateMarker,
-} from './note-marker';
+} from '../note-marker';
 
 // The marker is what partitions the shared account card: the account's own
 // notes plus one pending row per new candidate all live under one key, and


### PR DESCRIPTION
Closes #34 (issue C1).

PDFs now extract **vision-first** via `gemini-3.5-flash` document understanding (inline PDF bytes on `generateContent` through the existing `@google/genai` client — no new SDK), returning the same `ExtractionOutcome` shape with `extractor='vision'`. The transcription prompt is normalized to the walkers' marker contract (`# Title`, `## Page N`, tab-separated tables, bracketed one-line chart/image descriptions), so `interpret.ts` consumes it unchanged — **no C3 escalation needed**.

## Semantics

- **Fallback, never failure:** every vision gate and failure (kill switch, mock LLM driver, size/page caps, API error, timeout, empty transcription) falls back silently to the unpdf text-layer path (`extractor='pdf'`). Vision never fails a scan, never drops a file, never produces a skip. Only when the fallback *also* fails does the existing throw-to-sync behavior kick in (test pinned).
- **Lockstep:** because the vision branch is skip-neutral, `predictExtractionSkip`'s decision tree is unchanged by construction; a new matrix test pins predict↔extract agreement across all MIME/shortcut/size cases (18 cases), and a comment at the PDF case documents the mirroring obligation for any future vision-produced skip.
- **Docs/Sheets/Slides untouched** — native APIs beat OCR. **PPTX stays on officeparser**: Gemini inline document understanding accepts PDF only (verified against current docs); decks get vision when they're PDF exports, which is the common agency case. A PPTX→PDF conversion step is deferred to the rich-pipeline plan.
- **Caps** (all env-tunable, defaults in `.env.example`): 14 MB raw bytes (base64 inflates 4/3 under the API's 20 MB inline-request limit), 50 pages (API max 1000, ~258 input tokens/page), 32k output tokens, 180 s per-file timeout. The `DRIVE_MAX_FILE_SIZE_BYTES` download cap and the whole skip taxonomy are preserved.
- `LlmCompletionRequest` grows `media[]` (inlineData parts) and `timeoutMs` (per-request `httpOptions`; re-pins SDK retries off so they don't stack with the driver's retry loop).

## Eval — vision vs text-layer, one real account (Chevy), 8 PDFs

Sampled evenly across the size range of the account's 1,138 vision-eligible PDFs. Quality scored 0–10 by a Gemini judge that sees the actual PDF plus both transcriptions (information completeness incl. charts/tables + structure fidelity). Pricing: $1.50/M input, $9.00/M output.

| File | Pages | Size | Text-layer (chars / latency) | Vision (chars / latency) | Vision tokens in/out | Vision cost | Quality text→vision |
|---|---|---|---|---|---|---|---|
| 20117a_E Ray_One_Color_on_White.pdf | 1 | 7 KB | **0 ch** / 9 ms | 263 ch / 5.6 s | 719 / 67 | $0.0017 | 0 → 10 |
| Holiday Strategy Discussion 04_21 v2.pdf | 1 | 27 KB | 1612 ch / 31 ms | 1651 ch / 2.8 s | 699 / 372 | $0.0044 | 8 → 10 |
| Chevy Estimate Workbook…HOLIDAY25 Travel Worksheet.pdf | 2 | 65 KB | 2727 ch / 18 ms | 2899 ch / 6.4 s | 1219 / 1218 | $0.0128 | 8 → 10 |
| Smart clock demo framework_en-GB.pdf | 3 | 115 KB | 5055 ch / 48 ms | 5205 ch / 6.8 s | 1739 / 1215 | $0.0135 | 7 → 9.5 |
| [6/19] Changes for BHAC Dealer Kit PDF.pdf | 3 | 229 KB | 1269 ch / 34 ms | 3302 ch / 5.1 s | 1760 / 806 | $0.0099 | 5 → 10 |
| Houston Astros Clearance_HAT.pdf | 5 | 566 KB | 9690 ch / 72 ms | 7143 ch / 10.7 s | 2779 / 2184 | $0.0238 | 8 → 9.5 |
| Heartbeat Film Messaging Matrix_ Feb 2026.pdf | 9 | 1.5 MB | 7567 ch / 65 ms | 10841 ch / 16.5 s | 4922 / 3223 | $0.0364 | 4 → 10 |
| Briley Jewelry Release.pdf | 1 | 4.1 MB | **0 ch** / 3 ms | 4564 ch / 6.1 s | 719 / 880 | $0.0090 | 0 → 10 |

**Totals: 14,556 prompt + 9,965 output tokens ≈ $0.11 for 8 files (avg ~$0.014/file, max $0.036).** Thinking tokens: 0 (`thinkingLevel: MINIMAL` holds).

Judge highlights: two image-set PDFs (logo proof, jewelry release) extract **nothing** via the text layer today — they were silently skipped as `empty`; vision recovers them fully. The Heartbeat matrix's page-3 flowchart and all table structure are text-layer casualties that vision preserves.

**Proposed per-file budget: $0.05** (covers the observed max ×1.4; at Chevy's 1,138 PDFs a full cold backfill would be ≤ ~$20 one-time, and delta-gated scans after that). Latency: 3–17 s/file adds to Cloud-Run-Job wall clock — the 50-page/14 MB caps bound the worst case, and `DRIVE_VISION_ENABLED=false` is the kill switch. Ratify or adjust before rollout.

## Notes for reviewers

- **contentHash churn:** vision text differs from text-layer text, so the first scan after deploy rewrites `content_hash` on PDF snapshots. Delta-skipping is `modifiedTime`-based, so this does **not** trigger re-extraction storms; it's cosmetic on the snapshot history.
- Repro: `npx tsx scripts/eval-vision-extraction.ts --account <name> --limit 8 --price-in 1.50 --price-out 9.00` (needs `DATABASE_URL`, bot-OAuth client env, Gemini auth). Read-only against Drive; no DB writes.
- `npx tsc --noEmit` clean (module the pre-existing stale-prisma-client noise in `src/forward/*` that `prisma generate` resolves); extract suite 37/37, full unit suite 48/48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
