### PR TITLE
feat: ungate piece-scoped images through vision extraction (C2)

### DIFF
--- a/scripts/eval-image-vision.ts
+++ b/scripts/eval-image-vision.ts
@@ -1,0 +1,258 @@
+/**
+ * eval-image-vision.ts — C2 (#35) yield eval: Gemini vision extraction on
+ * the images the C2 gate would actually admit — the ones inside
+ * folder-backed piece folders, within the size floor/cap.
+ *
+ * There is no baseline to compare against (pre-C2, images extract to
+ * nothing at all), so unlike the C1 eval this measures YIELD:
+ *   - scope: how many images live in piece scope at all (default mode)
+ *   - per admitted image: transcription length, emptiness, latency,
+ *     token usage/cost, plus a vision judge scoring how completely the
+ *     transcription captures the image's marketing-relevant content
+ * Prints a markdown table (for the PR) plus totals.
+ *
+ * Usage:
+ *   npx tsx scripts/eval-image-vision.ts                # scope table: images per piece
+ *   npx tsx scripts/eval-image-vision.ts --piece BHAC --limit 8 \
+ *     --price-in 0.30 --price-out 2.50                  # $/1M tokens
+ *
+ * Env: DATABASE_URL, GUB_BOT_OAUTH_CLIENT_ID/SECRET, and Gemini auth
+ * (GEMINI_USE_ENTERPRISE=true + GCP_PROJECT_ID, or GEMINI_API_KEY).
+ * Read-only against Drive; writes nothing to the DB.
+ */
+
+import { prisma } from '../src/prisma';
+import { downloadFileBuffer, getFileMetadata } from '../src/drive/client';
+import { visionExtractImage } from '../src/drive/extract-vision';
+import { isVisionEligibleImageMime } from '../src/drive/image-mimes';
+import { defaultLlm, SchemaType, type ResponseSchema } from '../src/ai';
+import { config } from '../src/config';
+
+interface Args {
+  piece: string | undefined;
+  limit: number;
+  priceIn: number; // $ per 1M input tokens
+  priceOut: number; // $ per 1M output tokens
+}
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2);
+  const get = (flag: string): string | undefined => {
+    const i = argv.indexOf(flag);
+    return i >= 0 ? argv[i + 1] : undefined;
+  };
+  return {
+    piece: get('--piece'),
+    limit: Number(get('--limit') ?? 8),
+    priceIn: Number(get('--price-in') ?? 0),
+    priceOut: Number(get('--price-out') ?? 0),
+  };
+}
+
+/** Scope table: every folder-backed piece and its image population. */
+async function listPieces(): Promise<void> {
+  const rows = await prisma.$queryRaw<
+    Array<{ piece: string; campaign: string; imgs: bigint; in_caps: bigint }>
+  >`
+    select p.name as piece, c.name as campaign,
+           count(distinct s.file_id) as imgs,
+           count(distinct s.file_id) filter (
+             where s.size_bytes >= ${config.DRIVE_IMAGE_MIN_FILE_SIZE_BYTES}
+               and s.size_bytes <= ${config.DRIVE_IMAGE_MAX_FILE_SIZE_BYTES}
+           ) as in_caps
+    from campaign_pieces p
+    join campaigns c on c.id = p.campaign_id
+    left join drive_file_snapshots s
+      on s.path like p.drive_folder_path || ' / %' and s.mime_type like 'image/%'
+    where p.drive_folder_path is not null
+    group by p.name, c.name
+    order by imgs desc`;
+  const total = await prisma.$queryRaw<Array<{ n: bigint }>>`
+    select count(distinct file_id) as n from drive_file_snapshots where mime_type like 'image/%'`;
+  console.log(`Images account-wide (all accounts): ${total[0]?.n ?? 0}`);
+  console.log('Folder-backed pieces and their image populations (size floor/cap applied):');
+  for (const r of rows) {
+    console.log(
+      `  ${String(r.imgs).padStart(4)} imgs (${String(r.in_caps).padStart(3)} in caps)  ` +
+        `${r.campaign} / ${r.piece}`,
+    );
+  }
+}
+
+interface Sampled {
+  fileId: string;
+  name: string;
+  mimeType: string;
+  sizeBytes: number | null;
+}
+
+async function samplePieceImages(pieceNeedle: string, limit: number): Promise<Sampled[]> {
+  const piece = await prisma.campaignPiece.findFirst({
+    where: {
+      name: { contains: pieceNeedle, mode: 'insensitive' },
+      driveFolderPath: { not: null },
+    },
+    select: { name: true, driveFolderPath: true },
+  });
+  if (!piece) throw new Error(`no folder-backed piece matching "${pieceNeedle}"`);
+  console.log(`Piece: ${piece.name}\nFolder: ${piece.driveFolderPath}\n`);
+
+  const rows = await prisma.$queryRaw<
+    Array<{ file_id: string; name: string; mime_type: string; size_bytes: bigint | null }>
+  >`
+    select distinct on (file_id) file_id, name, mime_type, size_bytes
+    from drive_file_snapshots
+    where path like ${piece.driveFolderPath + ' / %'} and mime_type like 'image/%'
+    order by file_id, scanned_at desc`;
+
+  // Exactly the C2 gate population: eligible mime + within floor/cap.
+  const eligible = rows
+    .filter((r) => isVisionEligibleImageMime(r.mime_type))
+    .filter(
+      (r) =>
+        r.size_bytes !== null &&
+        Number(r.size_bytes) >= config.DRIVE_IMAGE_MIN_FILE_SIZE_BYTES &&
+        Number(r.size_bytes) <= config.DRIVE_IMAGE_MAX_FILE_SIZE_BYTES,
+    )
+    .sort((a, b) => Number(a.size_bytes) - Number(b.size_bytes));
+  console.log(
+    `${rows.length} image(s) under the piece folder; ${eligible.length} pass mime + floor/cap gates.`,
+  );
+  if (eligible.length === 0) throw new Error('no gate-passing images for this piece');
+
+  // Even spread across the size range (same trick as the C1 eval).
+  const picked: Sampled[] = [];
+  const step = Math.max(1, Math.floor(eligible.length / limit));
+  for (let i = 0; i < eligible.length && picked.length < limit; i += step) {
+    const r = eligible[i]!;
+    picked.push({
+      fileId: r.file_id,
+      name: r.name,
+      mimeType: r.mime_type,
+      sizeBytes: r.size_bytes === null ? null : Number(r.size_bytes),
+    });
+  }
+  return picked;
+}
+
+const JUDGE_SCHEMA: ResponseSchema = {
+  type: SchemaType.OBJECT,
+  properties: {
+    score: { type: SchemaType.NUMBER },
+    notes: { type: SchemaType.STRING },
+  },
+  required: ['score', 'notes'],
+};
+
+async function judge(
+  mimeType: string,
+  buf: Buffer,
+  transcription: string,
+): Promise<{ score: number; notes: string }> {
+  const clip = (s: string) => (s.length > 12000 ? s.slice(0, 12000) + '\n…[clipped]' : s);
+  const res = await defaultLlm.complete({
+    model: config.DRIVE_VISION_MODEL || 'gemini-3.5-flash',
+    temperature: 0,
+    prompt: `The attached image was transcribed for a marketing-intelligence pipeline. Score the transcription 0-10 on how completely it captures the image's marketing-relevant content: legible text (headlines, body copy, CTAs, disclaimers), identifiable brand elements, and what the visual actually depicts. A transcription missing content clearly present in the image must lose points; an empty transcription of a content-free image (pure chrome) scores 10.
+
+=== TRANSCRIPTION ===
+${clip(transcription) || '(empty)'}`,
+    media: [{ mimeType, dataBase64: buf.toString('base64') }],
+    responseSchema: JUDGE_SCHEMA,
+    maxOutputTokens: 4096,
+    timeoutMs: config.DRIVE_VISION_TIMEOUT_MS,
+    tag: 'eval.image_vision_judge',
+  });
+  return JSON.parse(res.text) as { score: number; notes: string };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  if (!args.piece) {
+    await listPieces();
+    await prisma.$disconnect();
+    return;
+  }
+  const files = await samplePieceImages(args.piece, args.limit);
+  console.log(`Sampled ${files.length} gate-passing image(s).\n`);
+
+  const rows: string[] = [];
+  let totPromptTok = 0;
+  let totOutTok = 0;
+  let totThoughtTok = 0;
+  let nonEmpty = 0;
+
+  for (const f of files) {
+    const meta = await getFileMetadata(f.fileId);
+    if (!meta) {
+      console.log(`  SKIP (gone from Drive): ${f.name}`);
+      continue;
+    }
+    const buf = await downloadFileBuffer(f.fileId);
+
+    const t0 = Date.now();
+    let text = '';
+    let visionErr: string | null = null;
+    let usage:
+      | { promptTokens: number | null; outputTokens: number | null; thoughtsTokens: number | null }
+      | undefined;
+    try {
+      const r = await visionExtractImage(f.mimeType, buf);
+      text = r.text;
+      usage = r.usage;
+    } catch (e) {
+      visionErr = String(e).slice(0, 120);
+    }
+    const visionMs = Date.now() - t0;
+    if (text.length > 0) nonEmpty += 1;
+
+    totPromptTok += usage?.promptTokens ?? 0;
+    totOutTok += usage?.outputTokens ?? 0;
+    totThoughtTok += usage?.thoughtsTokens ?? 0;
+
+    let scores = { score: NaN, notes: visionErr ?? '' };
+    if (!visionErr) {
+      try {
+        scores = await judge(f.mimeType, buf, text);
+      } catch (e) {
+        scores.notes = `judge failed: ${String(e).slice(0, 80)}`;
+      }
+    }
+
+    const outTokBillable = (usage?.outputTokens ?? 0) + (usage?.thoughtsTokens ?? 0);
+    const cost =
+      args.priceIn && usage?.promptTokens
+        ? (usage.promptTokens / 1e6) * args.priceIn + (outTokBillable / 1e6) * args.priceOut
+        : null;
+
+    rows.push(
+      `| ${f.name.slice(0, 40)} | ${f.mimeType.slice(6)} | ${((buf.length / 1024) | 0)} KB | ` +
+        `${visionErr ? 'ERR' : text.length + ' ch'} / ${(visionMs / 1000).toFixed(1)} s | ` +
+        `${usage?.promptTokens ?? '—'} / ${outTokBillable || '—'} | ` +
+        `${cost === null ? '—' : '$' + cost.toFixed(4)} | ` +
+        `${Number.isNaN(scores.score) ? '—' : scores.score} | ` +
+        `${scores.notes.replace(/\|/g, '/').replace(/\n/g, ' ').slice(0, 110)} |`,
+    );
+    console.log(`  done: ${f.name} (${text.length} ch, ${(visionMs / 1000).toFixed(1)}s)`);
+  }
+
+  console.log(
+    '\n| File | Mime | Size | Vision (chars/latency) | Tokens in/out | Cost | Judge (0-10) | Judge notes |',
+  );
+  console.log('|---|---|---|---|---|---|---|---|');
+  for (const r of rows) console.log(r);
+  const totCost = args.priceIn
+    ? (totPromptTok / 1e6) * args.priceIn + ((totOutTok + totThoughtTok) / 1e6) * args.priceOut
+    : null;
+  console.log(
+    `\nYield: ${nonEmpty}/${rows.length} non-empty transcription(s).` +
+      `\nTotals: prompt=${totPromptTok} output=${totOutTok} thoughts=${totThoughtTok} tokens` +
+      (totCost === null ? '' : `; est. cost $${totCost.toFixed(4)} (${rows.length} files)`),
+  );
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -92,6 +92,39 @@ const EnvSchema = z.object({
    * the text path like any other vision failure.
    */
   DRIVE_VISION_TIMEOUT_MS: z.string().default('180000').transform(Number),
+
+  // ── Image vision extraction (issue C2 / #35) ─────────────────────────────
+  // image/* files inside FOLDER-BACKED PIECE FOLDERS go through Gemini image
+  // understanding, behind size/count caps and a metadata relevance floor.
+  // Everything else skips as out_of_scope_image. Unlike the PDF path there
+  // is NO text fallback — a vision gate/failure is a skip, never a scan
+  // failure. Ships dark: widen scope only after the yield table justifies it.
+  /** Dark-launch master switch — default OFF. While off, image/* behaves
+   *  byte-identically to pre-C2 (plain unsupported_mime skips). */
+  DRIVE_IMAGE_VISION_ENABLED: z
+    .string()
+    .default('false')
+    .transform((v) => v === 'true'),
+  /**
+   * Raw-byte cap for the image vision call. Same rationale (and default)
+   * as DRIVE_VISION_MAX_FILE_SIZE_BYTES: the API rejects inline requests
+   * over 20 MB TOTAL and base64 inflates by 4/3, so 14 MB raw ≈ 18.7 MB
+   * encoded + prompt headroom. Over-cap images skip (no fallback).
+   */
+  DRIVE_IMAGE_MAX_FILE_SIZE_BYTES: z.string().default('14680064').transform(Number),
+  /**
+   * Metadata relevance floor (the MVP relevance gate): images smaller than
+   * this are overwhelmingly chrome — icons, favicons, tiny logo cuts — not
+   * deliverables. They skip as out_of_scope_image without an LLM call. The
+   * batched LLM relevance classifier stays a documented later lever, gated
+   * on the yield measurement.
+   */
+  DRIVE_IMAGE_MIN_FILE_SIZE_BYTES: z.string().default('10240').transform(Number),
+  /** Count cap per piece per processed batch (= one scan day) — a piece
+   *  folder dumping 300 exports must not burn 300 vision calls. */
+  DRIVE_IMAGE_MAX_PER_PIECE: z.string().default('10').transform(Number),
+  /** Safety cap on image vision calls per processed batch, across pieces. */
+  DRIVE_IMAGE_MAX_PER_BATCH: z.string().default('50').transform(Number),
   /**
    * Worker-pool concurrency for the per-entity distill+synth+write loop
    * inside processBatch. Each entity owns a discrete status_markdown blob

--- a/src/drive/__tests__/extract.test.ts
+++ b/src/drive/__tests__/extract.test.ts
@@ -22,6 +22,16 @@
  *   - predictExtractionSkip ↔ extractText lockstep: across the whole MIME
  *     matrix, a predicted skip is returned verbatim by extractText and a
  *     predicted null extracts ok — the vision branch must stay skip-neutral
+ *
+ * Image vision path (issue C2 / #35): images have NO text fallback, so —
+ * unlike PDF — the image branch is skip-producing, and the lockstep matrix
+ * covers it under both allowImageVision=true and =false. We pin:
+ *   - in-scope success → extractor='vision-image'
+ *   - no scope granted → out_of_scope_image (worker detail threaded through)
+ *   - dark launch (flag off) and mock driver → pre-C2 unsupported_mime,
+ *     byte-identical detail
+ *   - vision error → detail-tagged unsupported_mime skip, never a throw
+ *   - empty transcription → ordinary 'empty' skip
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -71,6 +81,10 @@ const { mockConfig, CONFIG_DEFAULTS } = vi.hoisted(() => {
     DRIVE_VISION_MAX_PDF_PAGES: 50,
     DRIVE_VISION_MAX_OUTPUT_TOKENS: 32768,
     DRIVE_VISION_TIMEOUT_MS: 180000,
+    // Image vision (C2): the unit suite exercises the LIVE path; the
+    // dark-launch default (false) is pinned by an explicit test below.
+    DRIVE_IMAGE_VISION_ENABLED: true,
+    DRIVE_IMAGE_MAX_FILE_SIZE_BYTES: 14680064,
   };
   return { mockConfig: { ...CONFIG_DEFAULTS }, CONFIG_DEFAULTS };
 });
@@ -593,11 +607,103 @@ describe('extractText PDF vision path', () => {
   });
 });
 
+// ── Image vision path (issue C2 / #35) ──────────────────────────────────────
+// Images have no text fallback: every gate and failure must be a SKIP with
+// the pinned reason/detail, never a throw. Scope is the caller's verdict
+// (opts.allowImageVision) — extractText only honors it.
+
+describe('extractText image vision path (issue C2)', () => {
+  const imageFile = (overrides: Partial<TraversedFile> = {}): TraversedFile =>
+    makeFile({ mimeType: 'image/png', name: 'key-visual.png', ...overrides });
+  const ALLOW = { allowImageVision: true };
+
+  it('extracts an in-scope image via vision (extractor=vision-image)', async () => {
+    llmComplete.mockResolvedValue({
+      text: '# Key Visual\n[Poster: bottle on yellow field]',
+      driver: 'gemini',
+      model: 'gemini-3.5-flash',
+    });
+    const outcome = await extractText(imageFile(), ALLOW);
+    expect(outcome).toMatchObject({ kind: 'ok', extractor: 'vision-image' });
+    expect(llmComplete).toHaveBeenCalledTimes(1);
+    // The image's own mime rides the media part (PDF hardcodes application/pdf).
+    expect(llmComplete.mock.calls[0]![0]).toMatchObject({
+      media: [{ mimeType: 'image/png', dataBase64: expect.any(String) }],
+    });
+  });
+
+  it('skips out_of_scope_image when the caller granted no scope', async () => {
+    const outcome = await extractText(imageFile());
+    expect(outcome).toEqual({ kind: 'skip', reason: 'out_of_scope_image' });
+    expect(llmComplete).not.toHaveBeenCalled();
+    expect(downloadFileBuffer).not.toHaveBeenCalled();
+  });
+
+  it('threads the worker skip detail (per_piece_cap) into the skip', async () => {
+    const outcome = await extractText(imageFile(), {
+      allowImageVision: false,
+      imageSkipDetail: 'per_piece_cap',
+    });
+    expect(outcome).toEqual({
+      kind: 'skip',
+      reason: 'out_of_scope_image',
+      detail: 'per_piece_cap',
+    });
+  });
+
+  it('dark launch: flag off → pre-C2 unsupported_mime even when scope was granted', async () => {
+    mockConfig.DRIVE_IMAGE_VISION_ENABLED = false;
+    const outcome = await extractText(imageFile(), ALLOW);
+    expect(outcome).toEqual({ kind: 'skip', reason: 'unsupported_mime', detail: 'image/png' });
+    expect(llmComplete).not.toHaveBeenCalled();
+    expect(downloadFileBuffer).not.toHaveBeenCalled();
+  });
+
+  it('mock LLM driver → gate-off unsupported_mime (stub output must not become "text")', async () => {
+    llmDriver.name = 'mock';
+    const outcome = await extractText(imageFile(), ALLOW);
+    expect(outcome).toEqual({ kind: 'skip', reason: 'unsupported_mime', detail: 'image/png' });
+    expect(llmComplete).not.toHaveBeenCalled();
+  });
+
+  it('vision error → detail-tagged skip, never a throw (no fallback to lose to)', async () => {
+    llmComplete.mockRejectedValue(new Error('vision down'));
+    const outcome = await extractText(imageFile(), ALLOW);
+    expect(outcome).toMatchObject({ kind: 'skip', reason: 'unsupported_mime' });
+    expect((outcome as { detail?: string }).detail).toMatch(/^image_vision_failed: vision down/);
+  });
+
+  it('empty transcription (pure chrome) → ordinary empty skip', async () => {
+    llmComplete.mockResolvedValue({ text: '   ', driver: 'gemini', model: 'gemini-3.5-flash' });
+    const outcome = await extractText(imageFile(), ALLOW);
+    expect(outcome).toEqual({ kind: 'skip', reason: 'empty', detail: 'extractor=vision-image' });
+  });
+
+  it('enforces the byte cap on the ACTUAL download when metadata size is unknown', async () => {
+    mockConfig.DRIVE_IMAGE_MAX_FILE_SIZE_BYTES = 4;
+    vi.mocked(downloadFileBuffer).mockResolvedValue(Buffer.from('123456789'));
+    const outcome = await extractText(imageFile({ size: null }), ALLOW);
+    expect(outcome).toMatchObject({ kind: 'skip', reason: 'out_of_scope_image' });
+    expect((outcome as { detail?: string }).detail).toMatch(/^over_size_cap /);
+    expect(llmComplete).not.toHaveBeenCalled();
+  });
+
+  it('non-inline image mimes (SVG) stay plain unsupported_mime even with scope', async () => {
+    const outcome = await extractText(
+      imageFile({ mimeType: 'image/svg+xml', name: 'logo.svg' }),
+      ALLOW,
+    );
+    expect(outcome).toEqual({ kind: 'skip', reason: 'unsupported_mime', detail: 'image/svg+xml' });
+  });
+});
+
 // ── predictExtractionSkip ↔ extractText lockstep ────────────────────────────
 // The two functions walk one decision tree; this matrix pins that a
 // predicted skip is returned VERBATIM by extractText and a predicted null
 // really extracts. The vision branch must stay skip-neutral: PDFs predict
 // null whether vision or the text layer ends up producing the text.
+// Images (C2) are the opposite — the branch is skip-PRODUCING — so the
+// matrix pins agreement under both allowImageVision=true and =false.
 
 describe('predictExtractionSkip ↔ extractText lockstep', () => {
   const DOCX_MIME =
@@ -605,9 +711,53 @@ describe('predictExtractionSkip ↔ extractText lockstep', () => {
   const PPTX_MIME =
     'application/vnd.openxmlformats-officedocument.presentationml.presentation';
 
-  const matrix: Array<{ label: string; file: TraversedFile; setup?: () => void }> = [
+  const matrix: Array<{
+    label: string;
+    file: TraversedFile;
+    opts?: { allowImageVision?: boolean; imageSkipDetail?: string };
+    setup?: () => void;
+  }> = [
     { label: 'folder', file: makeFile({ isFolder: true, mimeType: 'application/vnd.google-apps.folder' }) },
-    { label: 'unsupported mime (image/png)', file: makeFile({ mimeType: 'image/png' }) },
+    { label: 'image/png without granted scope (out_of_scope_image)', file: makeFile({ mimeType: 'image/png' }) },
+    {
+      label: 'image/png with granted scope (vision on) — extracts',
+      file: makeFile({ mimeType: 'image/png', name: 'kv.png' }),
+      opts: { allowImageVision: true },
+    },
+    {
+      label: 'image/png with granted scope but vision dark (flag off)',
+      file: makeFile({ mimeType: 'image/png', name: 'kv.png' }),
+      opts: { allowImageVision: true },
+      setup: () => {
+        mockConfig.DRIVE_IMAGE_VISION_ENABLED = false;
+      },
+    },
+    {
+      label: 'image/png with granted scope under the mock LLM driver',
+      file: makeFile({ mimeType: 'image/png', name: 'kv.png' }),
+      opts: { allowImageVision: true },
+      setup: () => {
+        llmDriver.name = 'mock';
+      },
+    },
+    {
+      label: 'image/png with granted scope over the image size cap',
+      file: makeFile({ mimeType: 'image/png', name: 'kv.png', size: 14680065 }),
+      opts: { allowImageVision: true },
+    },
+    {
+      label: 'image denied with a worker detail (per_piece_cap)',
+      file: makeFile({ mimeType: 'image/png', name: 'kv.png' }),
+      opts: { allowImageVision: false, imageSkipDetail: 'per_piece_cap' },
+    },
+    { label: 'image mime the API rejects (image/svg+xml)', file: makeFile({ mimeType: 'image/svg+xml' }) },
+    {
+      label: 'shortcut to an image without granted scope',
+      file: makeFile({
+        mimeType: 'application/vnd.google-apps.shortcut',
+        shortcutTarget: { id: 't1', mimeType: 'image/png' },
+      }),
+    },
     { label: 'PDF over the download cap', file: makeFile({ size: 26214401 }) },
     { label: 'PDF within caps (vision on)', file: makeFile({}) },
     {
@@ -684,11 +834,11 @@ describe('predictExtractionSkip ↔ extractText lockstep', () => {
     },
   ];
 
-  for (const { label, file, setup } of matrix) {
+  for (const { label, file, opts, setup } of matrix) {
     it(`agrees on ${label}`, async () => {
       setup?.();
-      const predicted = predictExtractionSkip(file);
-      const actual = await extractText(file);
+      const predicted = predictExtractionSkip(file, opts);
+      const actual = await extractText(file, opts);
       if (predicted) {
         // Predicted skips must be returned verbatim — same reason AND detail.
         expect(actual).toEqual(predicted);

--- a/src/drive/extract-vision.ts
+++ b/src/drive/extract-vision.ts
@@ -1,6 +1,6 @@
 /**
  * extract-vision.ts — Gemini document-understanding ("vision") extraction
- * for PDFs (issue C1 / #34).
+ * for PDFs (issue C1 / #34) and piece-scoped images (issue C2 / #35).
  *
  * The text-layer parser (unpdf) reads only the PDF's embedded text: it
  * loses layout, charts, and everything in image-set decks (a designed
@@ -17,10 +17,18 @@
  *     exports (the common agency case). Google Slides stays on the
  *     native Slides API (structured text beats OCR; see extract.ts).
  *
- * Failure posture: a vision failure must NEVER fail the scan or drop a
- * file. Every gate and error here returns null, and extract.ts falls
- * back to the text-layer path. There is no `vision_failed` skip reason
- * by design — vision failing is a downgrade, not a skip.
+ * Failure posture (PDF): a vision failure must NEVER fail the scan or
+ * drop a file. Every gate and error here returns null, and extract.ts
+ * falls back to the text-layer path. There is no `vision_failed` skip
+ * reason by design — vision failing is a downgrade, not a skip.
+ *
+ * Failure posture (image, C2): images have NO text fallback, so the image
+ * path is not skip-neutral the way the PDF path is. A gate-off returns
+ * the pre-C2 unsupported_mime skip (dark launch stays a no-op), a vision
+ * error returns a detail-tagged unsupported_mime skip (the file still
+ * feeds the name-only asset-folder path), and an empty transcription
+ * becomes the ordinary `empty` skip. Nothing here ever throws or fails
+ * the scan.
  *
  * Output contract: the SAME flat marked-up text the Google-native
  * walkers emit (`# Title`, `## <section>` markers, tab-separated table
@@ -31,7 +39,7 @@ import { config } from '../config';
 import { logger } from '../logger';
 import { defaultLlm, DEFAULT_GEMINI_MODEL } from '../ai';
 import type { LlmUsage } from '../ai';
-import type { TraversedFile } from './types';
+import type { ExtractionSkip, TraversedFile } from './types';
 
 /**
  * Mirrors the walkers' marker contract: `#` title, `##` per-page
@@ -143,5 +151,114 @@ export async function tryVisionPdfExtraction(
       '[drive.vision] vision_failed — falling back to text-layer path',
     );
     return null;
+  }
+}
+
+// ── Image extraction (issue C2 / #35) ───────────────────────────────────────
+
+/**
+ * Same marker contract as VISION_PROMPT (`#` title, bracketed one-line
+ * visual descriptions, flat text) so interpret.ts consumes image output
+ * unchanged. In an agency Drive the image often IS the deliverable — key
+ * visual, poster, mockup — so beyond legible text we ask for the brand /
+ * creative content a name-only pass would miss. Chrome (icons, UI
+ * fragments) transcribes to nothing → the ordinary `empty` skip; that
+ * emptiness is the implicit relevance backstop behind the metadata floor.
+ */
+const VISION_IMAGE_PROMPT = `You are a creative-asset transcription engine. Transcribe the attached image into flat, structured plain text for a marketing-intelligence pipeline.
+
+Rules:
+- If the image carries an evident title or headline, emit "# <headline>" as the first line.
+- Transcribe ALL legible text in natural reading order: headlines, body copy, captions, calls to action, disclaimers.
+- Add a one-line description of the visual in square brackets, e.g. [Poster: product bottle on a yellow field, bold retro typography].
+- Note identifiable brand and creative elements (logos, product shots, taglines, recurring campaign motifs) as plain text lines.
+- If the image is pure interface chrome, an icon, or a decorative fragment with no marketing or creative content, output nothing at all.
+- Output the transcription only — no preamble, no commentary, no code fences.`;
+
+/**
+ * Synchronous runtime gate for the image path, shared by extractText AND
+ * predictExtractionSkip so the two stay in lockstep: while this is false,
+ * every image/* file skips exactly as it did before C2 (unsupported_mime).
+ * The mock-driver check mirrors the PDF gate — a schema-shaped stub must
+ * not be stored as extracted text in dev.
+ */
+export function imageVisionRuntimeAvailable(): boolean {
+  return config.DRIVE_IMAGE_VISION_ENABLED && defaultLlm.name !== 'mock';
+}
+
+/**
+ * The raw image vision call — no gating, throws on error. Exposed
+ * separately (like visionExtractPdf) so an eval script can measure it
+ * without the skip semantics swallowing failures.
+ */
+export async function visionExtractImage(
+  mimeType: string,
+  buf: Buffer,
+): Promise<VisionExtractionResult> {
+  const model = config.DRIVE_VISION_MODEL || DEFAULT_GEMINI_MODEL;
+  const result = await defaultLlm.complete({
+    model,
+    temperature: 0,
+    prompt: VISION_IMAGE_PROMPT,
+    media: [{ mimeType, dataBase64: buf.toString('base64') }],
+    maxOutputTokens: config.DRIVE_VISION_MAX_OUTPUT_TOKENS,
+    // Same rationale as the PDF call: transcription doesn't need
+    // reasoning, and thinking tokens count against maxOutputTokens.
+    thinkingLevel: 'MINIMAL',
+    timeoutMs: config.DRIVE_VISION_TIMEOUT_MS,
+    tag: 'drive.image_vision_extraction.v1',
+  });
+  return { text: result.text.trim(), model, ...(result.usage ? { usage: result.usage } : {}) };
+}
+
+/**
+ * Image vision with the runtime gates applied. Returns the transcription
+ * text on success (possibly empty — extract.ts's ok() turns that into the
+ * ordinary `empty` skip), or an ExtractionSkip on any gate or failure.
+ * NEVER throws: images have no text fallback, so a vision problem must be
+ * a skip, not a scan failure. Scope/cap/relevance gating happened in the
+ * caller (the scan worker) before the bytes were ever downloaded — this
+ * function only enforces the gates that need the actual bytes or the
+ * runtime environment.
+ */
+export async function tryVisionImageExtraction(
+  file: Pick<TraversedFile, 'id' | 'name' | 'mimeType'>,
+  buf: Buffer,
+): Promise<string | ExtractionSkip> {
+  // Gate-off → the EXACT skip images produced before C2, so the dark
+  // launch (flag off) and dev (mock driver) are behavior no-ops.
+  if (!imageVisionRuntimeAvailable()) {
+    return { kind: 'skip', reason: 'unsupported_mime', detail: file.mimeType };
+  }
+  // Actual-byte cap (predict checked Drive's size metadata; this is the
+  // authoritative check on what we really downloaded).
+  if (buf.length > config.DRIVE_IMAGE_MAX_FILE_SIZE_BYTES) {
+    logger.debug(
+      { fileId: file.id, name: file.name, sizeBytes: buf.length },
+      '[drive.vision] image over vision size cap — skipping (no fallback)',
+    );
+    return {
+      kind: 'skip',
+      reason: 'out_of_scope_image',
+      detail: `over_size_cap size=${buf.length} limit=${config.DRIVE_IMAGE_MAX_FILE_SIZE_BYTES}`,
+    };
+  }
+
+  try {
+    const { text } = await visionExtractImage(file.mimeType, buf);
+    return text;
+  } catch (err) {
+    // Transient faults were already retried inside the LLM driver. The
+    // detail-tagged unsupported_mime keeps the file on the name-only
+    // asset-folder path — the filename still contributes evidence.
+    logger.warn(
+      { err, fileId: file.id, name: file.name, sizeBytes: buf.length, mimeType: file.mimeType },
+      '[drive.vision] image_vision_failed — skipping (images have no text fallback)',
+    );
+    return {
+      kind: 'skip',
+      reason: 'unsupported_mime',
+      detail: `image_vision_failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
   }
 }

--- a/src/drive/extract.ts
+++ b/src/drive/extract.ts
@@ -24,6 +24,13 @@
  *       extract-vision.ts for the gates and the failure posture
  *     - application/vnd.openxmlformats-…wordprocessingml.document  → mammoth (.docx)
  *     - text/* (plaintext, markdown, csv, etc.) → direct download (extractor='plaintext')
+ *     - image/* (PNG/JPEG/WEBP/HEIC/HEIF only) → Gemini image understanding
+ *       (extractor='vision-image'), issue C2 / #35. Scope-gated by the
+ *       CALLER via opts.allowImageVision — only the scan worker knows piece
+ *       scope — and by DRIVE_IMAGE_VISION_ENABLED (default off: dark launch
+ *       keeps the pre-C2 unsupported_mime behavior). Out-of-scope images
+ *       skip with reason='out_of_scope_image'. Unlike PDF vision there is
+ *       NO text fallback: vision gates/failures are skips, never throws.
  *
  *   Anything else → skip with reason='unsupported_mime'.
  *
@@ -44,7 +51,12 @@ import {
 import { config } from '../config';
 import { logger } from '../logger';
 import { downloadFileBuffer } from './client';
-import { tryVisionPdfExtraction } from './extract-vision';
+import {
+  imageVisionRuntimeAvailable,
+  tryVisionImageExtraction,
+  tryVisionPdfExtraction,
+} from './extract-vision';
+import { isVisionEligibleImageMime } from './image-mimes';
 import { buildBotOAuthClient } from '../workspace';
 import type { ExtractionOutcome, ExtractionSkip, TraversedFile } from './types';
 
@@ -136,6 +148,21 @@ function tooLargeForBinaryDownload(file: TraversedFile): ExtractionSkip | null {
 }
 
 /**
+ * Caller-supplied scope decision for image/* files (issue C2 / #35).
+ * Piece scope, count caps, and the relevance floor live in the scan
+ * worker — the only call site that knows which piece owns a file — so
+ * extractText can't compute them; it just honors the verdict. Callers
+ * that pass nothing get allowImageVision=false, i.e. images stay gated.
+ */
+export interface ExtractOptions {
+  /** True only when the scan worker granted this image the vision path. */
+  allowImageVision?: boolean;
+  /** Why the worker denied it — threaded into the out_of_scope_image
+   *  skip's detail (e.g. 'no_piece_scope', 'per_piece_cap'). */
+  imageSkipDetail?: string;
+}
+
+/**
  * Pure metadata-only check: would extractText skip this file without
  * doing any I/O? Returns the skip outcome if so, null if the file is
  * extraction-eligible (or would fail with a network/parse error, which
@@ -144,10 +171,13 @@ function tooLargeForBinaryDownload(file: TraversedFile): ExtractionSkip | null {
  * Mirrors the bail-outs in extractText so callers can predict the
  * outcome without any I/O.
  * Both predictExtractionSkip and extractText route through the same
- * decision tree — extractText calls this first, then proceeds to the
- * extraction switch only on null.
+ * decision tree — extractText calls this first (with the SAME opts),
+ * then proceeds to the extraction switch only on null.
  */
-export function predictExtractionSkip(file: TraversedFile): ExtractionSkip | null {
+export function predictExtractionSkip(
+  file: TraversedFile,
+  opts?: ExtractOptions,
+): ExtractionSkip | null {
   if (file.isFolder) return { kind: 'skip', reason: 'folder' };
 
   // Shortcut resolution — mirror extractText's three early-exit cases.
@@ -211,6 +241,44 @@ export function predictExtractionSkip(file: TraversedFile): ExtractionSkip | nul
     }
 
     default:
+      // ── image/* (issue C2 / #35) ────────────────────────────────────
+      // Lockstep with extractText's image case AND the gates inside
+      // tryVisionImageExtraction: whatever skip the runtime would return
+      // for metadata-visible reasons is predicted here.
+      if (isVisionEligibleImageMime(effective.mimeType)) {
+        // Dark launch / mock driver: byte-identical to pre-C2 — a plain
+        // unsupported_mime with the mime as detail.
+        if (!imageVisionRuntimeAvailable()) {
+          return { kind: 'skip', reason: 'unsupported_mime', detail: effective.mimeType };
+        }
+        // Scope is the caller's verdict (piece folder + caps + relevance
+        // floor, computed in the scan worker). No opts = not granted.
+        if (!opts?.allowImageVision) {
+          return {
+            kind: 'skip',
+            reason: 'out_of_scope_image',
+            ...(opts?.imageSkipDetail ? { detail: opts.imageSkipDetail } : {}),
+          };
+        }
+        // Size gates, mirroring tryVisionImageExtraction's byte cap from
+        // Drive's size metadata (no fallback → out_of_scope_image, not
+        // too_large: the file still feeds the name-only asset path).
+        if (effective.size && effective.size > config.DRIVE_IMAGE_MAX_FILE_SIZE_BYTES) {
+          return {
+            kind: 'skip',
+            reason: 'out_of_scope_image',
+            detail: `over_size_cap size=${effective.size} limit=${config.DRIVE_IMAGE_MAX_FILE_SIZE_BYTES}`,
+          };
+        }
+        if (isShortcutFollow && effective.size == null) {
+          return {
+            kind: 'skip',
+            reason: 'shortcut_unverified_size',
+            detail: `${effective.mimeType} via shortcut (target id=${effective.id}); shortcutDetails has no size`,
+          };
+        }
+        return null;
+      }
       if (effective.mimeType.startsWith('text/')) {
         const tooLarge = tooLargeForBinaryDownload(effective);
         if (tooLarge) return tooLarge;
@@ -227,9 +295,12 @@ export function predictExtractionSkip(file: TraversedFile): ExtractionSkip | nul
   }
 }
 
-export async function extractText(file: TraversedFile): Promise<ExtractionOutcome> {
+export async function extractText(
+  file: TraversedFile,
+  opts?: ExtractOptions,
+): Promise<ExtractionOutcome> {
   // Single source of truth for skip-without-I/O decisions.
-  const predicted = predictExtractionSkip(file);
+  const predicted = predictExtractionSkip(file, opts);
   if (predicted) return predicted;
 
   // Resolve the shortcut to its target. predictExtractionSkip already
@@ -317,6 +388,19 @@ export async function extractText(file: TraversedFile): Promise<ExtractionOutcom
         return ok(text, 'pptx');
       }
       default: {
+        // ── image/* (issue C2 / #35) ──────────────────────────────────
+        // Reaching here means predictExtractionSkip said eligible: the
+        // runtime gate is open AND the caller granted scope. Images have
+        // NO text fallback (unlike the PDF vision branch above), so every
+        // gate/failure inside tryVisionImageExtraction returns a SKIP,
+        // never a throw — an unreadable image must never fail the scan.
+        // downloadFileBuffer errors still propagate on purpose: a 403
+        // here feeds the restricted-file worklist like any other binary.
+        if (isVisionEligibleImageMime(effectiveFile.mimeType)) {
+          const buf = await downloadFileBuffer(effectiveFile.id);
+          const vision = await tryVisionImageExtraction(effectiveFile, buf);
+          return typeof vision === 'string' ? ok(vision, 'vision-image') : vision;
+        }
         if (effectiveFile.mimeType.startsWith('text/')) {
           const buf = await downloadFileBuffer(effectiveFile.id);
           return ok(buf.toString('utf-8'), 'plaintext');

--- a/src/drive/image-mimes.ts
+++ b/src/drive/image-mimes.ts
@@ -1,0 +1,26 @@
+/**
+ * image-mimes.ts — which image/* mimes the vision path accepts (issue C2 / #35).
+ *
+ * Deliberately an ALLOW-LIST, not `startsWith('image/')`: Gemini inline
+ * image understanding accepts exactly PNG / JPEG / WEBP / HEIC / HEIF.
+ * Everything else under image/* (SVG, GIF, TIFF, BMP, PSD-as-image…) would
+ * be a guaranteed API error, so those keep skipping as unsupported_mime —
+ * same as before C2.
+ *
+ * Kept dependency-free so the scan planner and its hermetic unit tests can
+ * import it without pulling the LLM driver (and its prisma-importing preset
+ * service) into the unit suite.
+ */
+
+const VISION_IMAGE_MIMES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/heic',
+  'image/heif',
+]);
+
+/** True when this mime is an image the Gemini vision path can ingest inline. */
+export function isVisionEligibleImageMime(mimeType: string): boolean {
+  return VISION_IMAGE_MIMES.has(mimeType);
+}

--- a/src/drive/sync.ts
+++ b/src/drive/sync.ts
@@ -158,15 +158,20 @@ async function processFile(
   const outcome = await extractText(file);
 
   if (outcome.kind === 'skip') {
+    // out_of_scope_image (C2 / #35) buckets with the mime skips: it's the
+    // same "this file type isn't extracted here" family, and ScanLogCategory
+    // is DB-CHECK-constrained — a new category needs a migration. The real
+    // reason survives in the message + snapshot skipReason.
     const category: ScanLogCategory =
       outcome.reason === 'too_large'
         ? 'skipped_size'
-        : outcome.reason === 'unsupported_mime'
+        : outcome.reason === 'unsupported_mime' || outcome.reason === 'out_of_scope_image'
           ? 'skipped_mime'
           : 'diagnostic';
 
     if (outcome.reason === 'too_large') result.filesSkippedSize++;
-    else if (outcome.reason === 'unsupported_mime') result.filesSkippedMime++;
+    else if (outcome.reason === 'unsupported_mime' || outcome.reason === 'out_of_scope_image')
+      result.filesSkippedMime++;
     else if (outcome.reason === 'empty') result.filesEmpty++;
 
     // Folder/empty/etc. still deserve a snapshot for history; only log the

--- a/src/drive/types.ts
+++ b/src/drive/types.ts
@@ -61,6 +61,13 @@ export interface ExtractionSkip {
      *  size, and downloading a multi-hundred-MB binary just to discover
      *  it exceeds the cap is the OOM vector we're guarding. */
     | 'shortcut_unverified_size'
+    /** Image vision (issue C2 / #35) is scoped to folder-backed piece
+     *  folders behind size/count caps and a relevance floor. Any image the
+     *  worker did NOT grant scope to — outside a piece folder, over a cap,
+     *  under the relevance floor — skips with this reason (detail says
+     *  which gate). Only emitted while DRIVE_IMAGE_VISION_ENABLED is on;
+     *  dark-launched images keep skipping as plain unsupported_mime. */
+    | 'out_of_scope_image'
     | 'empty'
     | 'delta_unchanged';
   detail?: string;

--- a/src/scan/__tests__/image-vision-plan.test.ts
+++ b/src/scan/__tests__/image-vision-plan.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for the image-vision scope/cap planner (issue C2 / #35).
+ *
+ * The planner is the worker-side half of the image gate: extract.ts only
+ * honors its verdict, so the scope narrowing, the relevance floor, and the
+ * per-piece/per-batch cap allocation are pinned HERE. Pure module — no
+ * config, prisma, or LLM driver — so the suite stays hermetic.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { planImageVision, NO_PIECE_SCOPE } from '../image-vision-plan';
+import type { TraversedFile } from '../../drive/types';
+
+const CAPS = {
+  minFileSizeBytes: 10_240,
+  maxFileSizeBytes: 14_680_064,
+  maxPerPiece: 2,
+  maxPerBatch: 3,
+};
+
+function file(id: string, overrides: Partial<TraversedFile> = {}): TraversedFile {
+  return {
+    id,
+    name: `${id}.png`,
+    mimeType: 'image/png',
+    path: `Acme / C1 / P1 / ${id}.png`,
+    modifiedTime: null,
+    modifiedByEmail: null,
+    createdTime: null,
+    size: 50_000,
+    isFolder: false,
+    ...overrides,
+  };
+}
+
+/** resolvePieceId stub: piece scope comes from the file's pieceId tag. */
+const byTag = (f: TraversedFile): string | null => f.pieceId ?? null;
+
+describe('planImageVision', () => {
+  it('grants vision to an in-scope image and records its piece', () => {
+    const plan = planImageVision([file('a', { pieceId: 'p1' })], byTag, CAPS);
+    expect(plan.get('a')).toEqual({ pieceId: 'p1', allowImageVision: true });
+  });
+
+  it('plans only vision-eligible images — folders, other mimes, and API-rejected image mimes get no entry', () => {
+    const plan = planImageVision(
+      [
+        file('folder', { isFolder: true, mimeType: 'application/vnd.google-apps.folder' }),
+        file('pdf', { mimeType: 'application/pdf', pieceId: 'p1' }),
+        file('svg', { mimeType: 'image/svg+xml', pieceId: 'p1' }),
+        file('img', { pieceId: 'p1' }),
+      ],
+      byTag,
+      CAPS,
+    );
+    expect([...plan.keys()]).toEqual(['img']);
+  });
+
+  it('scope gate: an image outside any piece folder is denied with no_piece_scope', () => {
+    const plan = planImageVision([file('a')], byTag, CAPS);
+    expect(plan.get('a')).toEqual({
+      pieceId: null,
+      allowImageVision: false,
+      skipDetail: NO_PIECE_SCOPE,
+    });
+  });
+
+  it('relevance floor: tiny images (chrome) are denied below_min_size', () => {
+    const plan = planImageVision([file('a', { pieceId: 'p1', size: 512 })], byTag, CAPS);
+    expect(plan.get('a')).toMatchObject({ allowImageVision: false });
+    expect(plan.get('a')!.skipDetail).toMatch(/^below_min_size /);
+  });
+
+  it('size cap: oversized images are denied over_size_cap', () => {
+    const plan = planImageVision([file('a', { pieceId: 'p1', size: 20_000_000 })], byTag, CAPS);
+    expect(plan.get('a')).toMatchObject({ allowImageVision: false });
+    expect(plan.get('a')!.skipDetail).toMatch(/^over_size_cap /);
+  });
+
+  it('unknown size passes both size gates (extract.ts re-checks the real bytes)', () => {
+    const plan = planImageVision([file('a', { pieceId: 'p1', size: null })], byTag, CAPS);
+    expect(plan.get('a')).toEqual({ pieceId: 'p1', allowImageVision: true });
+  });
+
+  it('per-piece cap: allocation is deterministic in batch order, excess denied per_piece_cap', () => {
+    const plan = planImageVision(
+      [file('a', { pieceId: 'p1' }), file('b', { pieceId: 'p1' }), file('c', { pieceId: 'p1' })],
+      byTag,
+      CAPS,
+    );
+    expect(plan.get('a')!.allowImageVision).toBe(true);
+    expect(plan.get('b')!.allowImageVision).toBe(true);
+    expect(plan.get('c')).toEqual({
+      pieceId: 'p1',
+      allowImageVision: false,
+      skipDetail: 'per_piece_cap',
+    });
+  });
+
+  it('per-piece cap slots are not burned by images other gates already denied', () => {
+    const plan = planImageVision(
+      [
+        file('tiny', { pieceId: 'p1', size: 512 }),
+        file('a', { pieceId: 'p1' }),
+        file('b', { pieceId: 'p1' }),
+      ],
+      byTag,
+      CAPS,
+    );
+    expect(plan.get('a')!.allowImageVision).toBe(true);
+    expect(plan.get('b')!.allowImageVision).toBe(true);
+  });
+
+  it('per-batch cap: grants across pieces stop at the batch cap with per_batch_cap', () => {
+    const plan = planImageVision(
+      [
+        file('a', { pieceId: 'p1' }),
+        file('b', { pieceId: 'p1' }),
+        file('c', { pieceId: 'p2' }),
+        file('d', { pieceId: 'p2' }),
+      ],
+      byTag,
+      CAPS,
+    );
+    expect(plan.get('c')!.allowImageVision).toBe(true);
+    expect(plan.get('d')).toEqual({
+      pieceId: 'p2',
+      allowImageVision: false,
+      skipDetail: 'per_batch_cap',
+    });
+  });
+});

--- a/src/scan/image-vision-plan.ts
+++ b/src/scan/image-vision-plan.ts
@@ -1,0 +1,106 @@
+/**
+ * image-vision-plan.ts — deterministic scope/cap allocation for image
+ * vision extraction (issue C2 / #35).
+ *
+ * The scan worker pool runs files in scheduler-dependent order, but which
+ * images win a vision slot must not depend on scheduling — so the whole
+ * batch's image gate decisions are computed HERE, in batch (file-index)
+ * order, before the pool starts. Three free gates, cheapest exclusion
+ * first:
+ *
+ *   1. Scope   — only images inside a folder-backed piece folder qualify
+ *                (the whole "piece folders first" narrowing). Content-born
+ *                pieces have no Drive folder → no files → invisible; an
+ *                accepted limitation of this phase.
+ *   2. Floor   — the metadata relevance gate: tiny files are chrome
+ *                (icons, favicons, logo cuts), not deliverables.
+ *   3. Caps    — per-piece and per-batch count caps bound the spend.
+ *
+ * Denied files carry a skipDetail that extract.ts threads into their
+ * out_of_scope_image skip. Pure module (no config/prisma imports) so the
+ * unit suite stays hermetic — caps come in as an argument.
+ */
+
+import { isVisionEligibleImageMime } from '../drive/image-mimes';
+import type { TraversedFile } from '../drive/types';
+
+export interface ImageVisionGate {
+  /** Piece scope resolved for this file; null = outside any folder-backed piece. */
+  pieceId: string | null;
+  /** The worker's verdict, passed to extractText as opts.allowImageVision. */
+  allowImageVision: boolean;
+  /** Why the gate denied vision — becomes the out_of_scope_image skip detail. */
+  skipDetail?: string;
+}
+
+export interface ImageVisionCaps {
+  /** Relevance floor: images smaller than this are chrome, not deliverables. */
+  minFileSizeBytes: number;
+  /** Inline-request byte cap (base64 inflation is why it's 14 MB, not 20). */
+  maxFileSizeBytes: number;
+  /** Vision-call cap per piece within this batch. */
+  maxPerPiece: number;
+  /** Vision-call cap across the whole batch. */
+  maxPerBatch: number;
+}
+
+/** Detail token for images with no piece scope (the scope gate). */
+export const NO_PIECE_SCOPE = 'no_piece_scope';
+
+/**
+ * Compute the image-vision gate for every vision-eligible image in the
+ * batch, keyed by file id. Files absent from the map are not images the
+ * vision path could ever take (folders, other mimes, image mimes the API
+ * rejects) and need no opts at all.
+ */
+export function planImageVision(
+  batch: TraversedFile[],
+  resolvePieceId: (file: TraversedFile) => string | null,
+  caps: ImageVisionCaps,
+): Map<string, ImageVisionGate> {
+  const plan = new Map<string, ImageVisionGate>();
+  const perPieceGranted = new Map<string, number>();
+  let batchGranted = 0;
+
+  for (const file of batch) {
+    if (file.isFolder || !isVisionEligibleImageMime(file.mimeType)) continue;
+
+    const pieceId = resolvePieceId(file);
+    if (!pieceId) {
+      plan.set(file.id, { pieceId: null, allowImageVision: false, skipDetail: NO_PIECE_SCOPE });
+      continue;
+    }
+    // Unknown size (null) passes both size gates here — extract.ts
+    // re-checks the byte cap on the actually-downloaded buffer.
+    if (file.size != null && file.size < caps.minFileSizeBytes) {
+      plan.set(file.id, {
+        pieceId,
+        allowImageVision: false,
+        skipDetail: `below_min_size size=${file.size} floor=${caps.minFileSizeBytes}`,
+      });
+      continue;
+    }
+    if (file.size != null && file.size > caps.maxFileSizeBytes) {
+      plan.set(file.id, {
+        pieceId,
+        allowImageVision: false,
+        skipDetail: `over_size_cap size=${file.size} limit=${caps.maxFileSizeBytes}`,
+      });
+      continue;
+    }
+    if ((perPieceGranted.get(pieceId) ?? 0) >= caps.maxPerPiece) {
+      plan.set(file.id, { pieceId, allowImageVision: false, skipDetail: 'per_piece_cap' });
+      continue;
+    }
+    if (batchGranted >= caps.maxPerBatch) {
+      plan.set(file.id, { pieceId, allowImageVision: false, skipDetail: 'per_batch_cap' });
+      continue;
+    }
+
+    perPieceGranted.set(pieceId, (perPieceGranted.get(pieceId) ?? 0) + 1);
+    batchGranted += 1;
+    plan.set(file.id, { pieceId, allowImageVision: true });
+  }
+
+  return plan;
+}

--- a/src/scan/process-batch.ts
+++ b/src/scan/process-batch.ts
@@ -45,6 +45,7 @@ import type { TraversedFile } from '../drive/types';
 import { config } from '../config';
 import { log, fmtBytes, fmtMs } from './output';
 import { timed } from './timing';
+import { planImageVision, NO_PIECE_SCOPE } from './image-vision-plan';
 import { runWithConcurrency } from './util';
 import { isForeignCampaignTag, routeCampaignObs, isDrivePermissionError, EMPTY_CAMPAIGN_STATE } from './routing';
 import {
@@ -224,6 +225,25 @@ export async function processBatch(
   /** Tagged campaign obs whose name fuzzy-matched (Levenshtein) to a known campaign — logged for visibility. */
   let fuzzyMatchedObs = 0;
 
+  // ── Image-vision yield counters (issue C2 / #35) ─────────────────────────
+  // The measurement that gates widening image scope beyond piece folders.
+  // Tracked even while DRIVE_IMAGE_VISION_ENABLED=false (dark), where they
+  // report what WOULD have been extracted.
+  /** Vision-eligible images whose piece scope resolved (the C2 population). */
+  let imagesInPieceScope = 0;
+  /** Images that extracted via vision (extractor='vision-image'). */
+  let imagesExtracted = 0;
+  /** Extracted images whose interpretation produced ≥1 observation. */
+  let imagesWithObs = 0;
+  /** out_of_scope_image skips from the scope gate (no piece folder). */
+  let imagesSkippedOutOfScope = 0;
+  /** out_of_scope_image skips from caps / the relevance floor. */
+  let imagesSkippedByCaps = 0;
+  /** Vision call failed (detail-tagged unsupported_mime — name-only path). */
+  let imagesVisionFailed = 0;
+  /** Vision returned an empty transcription (chrome — the implicit relevance check). */
+  let imagesVisionEmpty = 0;
+
   // Binaries-only folders: when EVERY file in a folder skips extraction on
   // mime (fonts, images, video), the per-file prompt never sees the folder
   // — but path + file names are still evidence ("Fonts/Louis-Bold.ttf"
@@ -328,10 +348,48 @@ export async function processBatch(
     };
   }
 
+  // ── Image-vision scope plan (issue C2 / #35) ──────────────────────────
+  // Computed for the WHOLE batch in file-index order BEFORE the pool runs,
+  // so per-piece/per-batch cap allocation never depends on worker
+  // scheduling (the pool's applyOutcome determinism doctrine). Piece scope
+  // comes from attribution.pieceId (account scans — piece-anchor overlay)
+  // or file.pieceId (campaign scans — tagged at discovery when gathering
+  // piece folders); both are folder-backed pieces. Content-born pieces
+  // (piece-derive.ts) have no driveFolderId → invisible to this gate.
+  const imageVisionPlan = planImageVision(
+    batch,
+    (file) => {
+      const attribution = resolveAttribution(file);
+      if (attribution.pieceId) return attribution.pieceId;
+      if (file.pieceId && piecesById?.has(file.pieceId)) return file.pieceId;
+      return null;
+    },
+    {
+      minFileSizeBytes: config.DRIVE_IMAGE_MIN_FILE_SIZE_BYTES,
+      maxFileSizeBytes: config.DRIVE_IMAGE_MAX_FILE_SIZE_BYTES,
+      maxPerPiece: config.DRIVE_IMAGE_MAX_PER_PIECE,
+      maxPerBatch: config.DRIVE_IMAGE_MAX_PER_BATCH,
+    },
+  );
+  for (const gate of imageVisionPlan.values()) {
+    if (gate.pieceId !== null) imagesInPieceScope += 1;
+  }
+
   async function runFileWorker(file: TraversedFile): Promise<WorkerOutcome> {
     const attribution = resolveAttribution(file);
+    const imageGate = imageVisionPlan.get(file.id);
     try {
-      const extraction = await timed('extract_text', () => extractText(file));
+      const extraction = await timed('extract_text', () =>
+        extractText(
+          file,
+          imageGate
+            ? {
+                allowImageVision: imageGate.allowImageVision,
+                ...(imageGate.skipDetail ? { imageSkipDetail: imageGate.skipDetail } : {}),
+              }
+            : undefined,
+        ),
+      );
       if (extraction.kind !== 'ok') {
         return {
           file,
@@ -410,7 +468,23 @@ export async function processBatch(
       const detail = o.skipDetail ? ` (${o.skipDetail})` : '';
       log(`    ⊘ ${file.name}  [${file.mimeType}]  skip: ${o.skipReason}${detail}`);
       filesSkipped++;
-      if (o.skipReason === 'unsupported_mime') {
+      // C2 yield accounting. Cap/floor denials carry a detail token from
+      // the plan; a bare (or no_piece_scope) out_of_scope_image is the
+      // scope gate. Vision failures and empty transcriptions are tagged
+      // by extract-vision / ok() respectively.
+      if (o.skipReason === 'out_of_scope_image') {
+        if (o.skipDetail && o.skipDetail !== NO_PIECE_SCOPE) imagesSkippedByCaps++;
+        else imagesSkippedOutOfScope++;
+      } else if (o.skipReason === 'empty' && o.skipDetail === 'extractor=vision-image') {
+        imagesVisionEmpty++;
+      } else if (o.skipReason === 'unsupported_mime' && o.skipDetail?.startsWith('image_vision_failed')) {
+        imagesVisionFailed++;
+      }
+      // out_of_scope_image joins unsupported_mime here ON PURPOSE: images
+      // C2 does not extract must keep feeding the name-only
+      // binaryOnlyFolders → interpretAssetFolder path exactly as before
+      // (their filenames are still evidence).
+      if (o.skipReason === 'unsupported_mime' || o.skipReason === 'out_of_scope_image') {
         const folderKey = file.parents?.[0] ?? parentPathOf(file);
         const rec = binaryOnlyFolders.get(folderKey);
         if (rec) {
@@ -506,6 +580,10 @@ export async function processBatch(
 
     try {
       const totalObs = res.account.length + res.campaign.length;
+      if (o.extractor === 'vision-image') {
+        imagesExtracted++;
+        if (totalObs > 0) imagesWithObs++;
+      }
       const symbol = totalObs > 0 ? '✓' : '○';
       const attrLabel =
         attribution.ownerType === 'campaign'
@@ -799,6 +877,19 @@ export async function processBatch(
   }
   if (filesRestored > 0) {
     log(`  🔓 ${filesRestored} previously restricted file(s) restored this scan`);
+  }
+  // C2 yield summary — the numbers that decide whether image scope widens
+  // beyond piece folders. Emitted whenever the batch held any vision-
+  // eligible image; in dark mode (flag off) it reports the would-be scope.
+  if (imageVisionPlan.size > 0) {
+    log(
+      `  🖼 Image vision (C2): eligible ${imageVisionPlan.size} · in piece scope ${imagesInPieceScope} · ` +
+        `extracted ${imagesExtracted} · non-empty obs ${imagesWithObs} · ` +
+        `out-of-scope skips ${imagesSkippedOutOfScope} · cap/floor skips ${imagesSkippedByCaps}` +
+        (imagesVisionEmpty > 0 ? ` · empty transcriptions ${imagesVisionEmpty}` : '') +
+        (imagesVisionFailed > 0 ? ` · vision failures ${imagesVisionFailed}` : '') +
+        (config.DRIVE_IMAGE_VISION_ENABLED ? '' : '  (dark — DRIVE_IMAGE_VISION_ENABLED=false)'),
+    );
   }
   log('');
 


### PR DESCRIPTION
Closes #35. Implements the C2 slice of the multimodal roadmap per `task-specs/issue-c2-image-ungating.md`: `image/*` files — until now dead-dropped as `unsupported_mime` — extract through the C1 vision path, but **narrowly**: only inside folder-backed piece folders, behind size/count caps and a metadata relevance floor, with a new explicit `out_of_scope_image` skip for everything else. Ships dark.

> **Stacked on #46** (`feat/c1-vision-extraction`) — C2 extends `extract-vision.ts`, which is not on `main` yet. Base is set to the C1 branch so the diff shows only C2; retarget to `main` after #46 merges (GitHub does this automatically on merge).

## How it works

Three free gates → vision → measure, cheapest exclusions first:

1. **Scope** (`src/scan/image-vision-plan.ts`) — an image qualifies only when its piece scope resolves: `attribution.pieceId` (account scans, piece-anchor overlay) or `file.pieceId` (campaign scans, tagged at discovery). Both are folder-backed pieces; the gate lives in `processBatch` because `runFileWorker` is the only extraction call site that knows piece scope.
2. **Relevance floor** — `DRIVE_IMAGE_MIN_FILE_SIZE_BYTES` (default 10 KB): tiny files are chrome (icons, favicons, logo cuts). The batched LLM relevance classifier from the spec is deliberately NOT built — it's the documented later lever, gated on the yield table.
3. **Caps** — `DRIVE_IMAGE_MAX_FILE_SIZE_BYTES` (14 MB, same base64-inflation math as the PDF cap), `DRIVE_IMAGE_MAX_PER_PIECE` (10), `DRIVE_IMAGE_MAX_PER_BATCH` (50). Cap allocation is computed for the whole batch in file-index order **before** the worker pool starts, so which images win vision slots never depends on worker scheduling (keeps the pool's determinism doctrine).

The worker passes its verdict into `extractText(file, { allowImageVision, imageSkipDetail })`; `predictExtractionSkip` takes the same opts and stays in lockstep (matrix test extended to pin image rows under both `allowImageVision=true` and `=false`). `tryVisionImageExtraction` mirrors `tryVisionPdfExtraction` but sends the image's own mime in `media[]` and uses an image-appropriate prompt emitting the same marker contract (`#` title, bracketed visual descriptions, flat text) that `interpret.ts` already consumes.

**Failure posture:** images have no text fallback, so unlike PDF vision this branch is skip-producing, never throw-producing. `downloadFileBuffer` errors still propagate on purpose — a 403 feeds the restricted-file worklist like any other binary.

| Situation | Outcome |
|---|---|
| `DRIVE_IMAGE_VISION_ENABLED=false` (default) or mock driver | `unsupported_mime`, detail = mime — **byte-identical to pre-C2** |
| In scope, extracted | `ok`, `extractor='vision-image'` |
| No piece scope | `out_of_scope_image` (`no_piece_scope`) |
| Below floor / over size cap / over count caps | `out_of_scope_image` (`below_min_size` / `over_size_cap` / `per_piece_cap` / `per_batch_cap`) |
| Vision call error | `unsupported_mime`, detail `image_vision_failed: …` (stays on the name-only path) |
| Empty transcription (pure chrome) | ordinary `empty` skip — the implicit relevance backstop |

**No downstream regression:** `out_of_scope_image` joins `unsupported_mime` in the `binaryOnlyFolders` collection, so non-extracted images keep feeding the name-only `interpretAssetFolder` path exactly as today.

## Yield measurement (eval run, prod-copy DB)

Scope reality first: the prod copy holds **10,844 distinct images account-wide**, of which exactly **5** sit inside a folder-backed piece folder (4 folder-backed pieces exist; one has images). That is the narrowing working as designed — and also why widening is a real future decision.

`scripts/eval-image-vision.ts` (added here, mirrors the C1 eval; read-only) on the full in-scope population — piece "Chevy | BHAC AI + LMA Tool", gemini-3.5-flash via the enterprise surface, prices $0.30/$2.50 per 1M tokens:

| File | Mime | Size | Vision (chars/latency) | Tokens in/out | Cost | Judge (0-10) |
|---|---|---|---|---|---|---|
| CHEVROLET EXT 1.jpg | jpeg | 331 KB | 184 ch / 3.7 s | 1284 / 44 | $0.0005 | 10 |
| CHEVROLET EXT 2.jpg | jpeg | 346 KB | 230 ch / 2.4 s | 1284 / 51 | $0.0005 | 10 |
| CHEVROLET EXT 3.jpg | jpeg | 353 KB | 228 ch / 1.8 s | 1284 / 52 | $0.0005 | 10 |
| Hero Soda Can.png | png | 706 KB | 168 ch / 1.8 s | 1248 / 37 | $0.0005 | 10 |
| BHAC_CHAR_GEN.png | png | 1464 KB | 224 ch / 2.0 s | 1284 / 48 | $0.0005 | 10 |

**Yield: 5/5 non-empty; total est. cost $0.0025.** All five are creative deliverables (Chevrolet exterior key visuals, a hero product shot, a character-gen frame) — exactly the signal the spec predicted piece folders would concentrate.

### Plan for the production yield table

1. Enable `DRIVE_IMAGE_VISION_ENABLED=true` on one eval account.
2. Run a scan; the batch summary now emits a `🖼 Image vision (C2)` line per batch: eligible / in-piece-scope / extracted / non-empty obs / out-of-scope skips / cap-floor skips (+ empty / failures when non-zero). The counters also run while dark, reporting the would-be scope.
3. Decision gate for widening (campaign folders next, then the LLM relevance classifier): non-empty-observation rate on in-scope images, and the out-of-scope skip volume telling us how much signal the scope gate is leaving on the table.

## Decisions worth flagging (deviations from the spec letter)

- **Piece scope includes `file.pieceId` on campaign scans.** The spec's condensed formula says `attribution.pieceId`, but that's always null on campaign-scoped scans (no attributor); `file.pieceId` (guarded by `piecesById`) is the same folder-backed piece signal there — matching how `pieceBuckets` are populated. Still strictly "folder-backed piece folders".
- **Allow-list, not `image/*`.** Gemini inline accepts exactly PNG/JPEG/WEBP/HEIC/HEIF; SVG/GIF/TIFF/etc. would be guaranteed API errors, so they keep skipping as `unsupported_mime` (`src/drive/image-mimes.ts`).
- **Oversized in-scope images → `out_of_scope_image`, not `too_large`.** The spec plan mentions `too_large`, but its acceptance criteria group over-cap under `out_of_scope_image`, and this keeps oversized images on the name-only asset-folder path (a `too_large` skip would drop them from `binaryOnlyFolders` — a regression).
- **Scan-log category for the new reason is `skipped_mime`.** `ScanLogCategory` is DB-CHECK-constrained; a new category needs a migration. The real reason survives in the log message and the snapshot `skip_reason` (plain String — TS-only change, as the spec notes).
- **`DRIVE_IMAGE_MIN_FILE_SIZE_BYTES` added** as the knob behind the metadata relevance floor (the spec's size/dimension floor; Drive metadata has no dimensions, so bytes it is).
- **Count caps are per processed batch (= one scan day).** Cross-day accounting would need DB state; these are safety caps, not budgets.
- **Known limitation (from the spec):** content-born pieces (`piece-derive.ts`) have no Drive folder → invisible to this gate. This is "folder-backed piece images", not "all piece images".

## Verification

- `tsc --noEmit` clean (the only errors on this machine are pre-existing `src/forward/*` ones from a stale local Prisma client, identical on the base branch; CI regenerates).
- `npm test`: 73/73 green — 9 new planner tests (scope gate, floor, caps incl. `per_piece_cap` detail, deterministic allocation), 9 new image-path tests (vision ok, out-of-scope, detail threading, dark launch, mock driver, error→skip, empty, byte cap, SVG), lockstep matrix extended with 8 image rows.
- Dark-launch default pinned by test: flag off → byte-identical pre-C2 behavior, no LLM call, no download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
