### PR TITLE
 feat: interpret-prompt contract update — vision-aware consumers + marker grammar (C3)

### DIFF
--- a/docs/file-extraction-prompt-vision-note.md
+++ b/docs/file-extraction-prompt-vision-note.md
@@ -1,0 +1,65 @@
+# `drive.file_extraction.v1` — vision-awareness update (C3 / #36)
+
+**Status: NOT applied by this repo.** The interpret prompt is a staff-edited row in
+`prompt_presets` (per D15 — see `docs/status-markdown-plan.md` and `status-synthesis.ts`), so
+there is deliberately no seed here. A human applies this edit via the prompt-authoring path
+(gub-admin → prompt presets → `drive.file_extraction.v1`). **Keep the key `v1`** — edit the
+template in place; changing the key would require an `interpret.ts` code change.
+
+## Why
+
+C1/C2 made extraction vision-rich: PDFs and piece-scoped images are transcribed by Gemini and
+arrive as `## Page N` sections with `[bracketed]` one-line descriptions of charts, posters, and
+creative visuals (see `src/drive/extract-markers.ts` — the marker grammar's single source of
+truth). The interpret prompt was written for flat native text and doesn't acknowledge those
+tokens, so vision's differentiating signal can be discarded as formatting noise. This edit
+teaches the prompt that the markers are structure and the bracketed lines are content.
+
+## The edit
+
+Insert the following block into the template **between the `Contents:` `"""` block and the
+`TASK` section** (match the template's two-space indent):
+
+```
+  NOTE ON CONTENTS — the text above is machine-extracted (Workspace API
+  walkers for Google-native files; Gemini vision transcription for PDFs
+  and images). It may contain structural markers:
+    - "# <title>" — the document/deck/workbook title (or an image's headline)
+    - "## Page N" / "## Slide N" / "## Sheet: <name>" — EQUIVALENT section
+      boundaries: which one appears depends only on the file type (a PDF's
+      pages are a deck's slides). Treat them identically.
+    - "### Speaker notes" — a slide's speaker notes
+    - tab-separated table rows
+    - one-line [bracketed] descriptions of charts, diagrams, images, and
+      creative visuals, e.g. [Chart: monthly revenue by region, peaks in
+      March] or [Poster: product bottle on a yellow field, bold retro
+      typography]
+  [Bracketed] lines are OBSERVED CONTENT — what the extractor saw on the
+  rendered page — not formatting noise. Mine them for substance exactly like
+  the surrounding text: a chart's stated trend can be a status or budget
+  signal, a described poster or key visual can reveal a campaign's creative
+  concept, positioning, or brand assets. A bracketed visual description
+  passes the POSITIVE TEST below the same way the equivalent sentence of
+  body copy would — judge it by what it says about THIS client's work.
+```
+
+Nothing else in the template changes: the agency filter, positive test, routing rules, deck-type
+classification, and output shape all stay as they are. The response schema is code
+(`structured-output.ts`) and is not touched by C3.
+
+The full updated template (current row + this block) is in the C3 PR body for copy-paste. The
+authoritative current text is always the DB row — if staff edited it after this note was
+written, re-anchor the block on the `Contents`/`TASK` boundary rather than pasting the PR's
+full text over their edits.
+
+## After applying — manual dev spot-check
+
+Vision-heavy behavior can't be unit-tested from this repo (the prompt is the DB row; the mock
+driver is gated off vision). After applying:
+
+1. Run a scan over a vision-heavy file (an image-set pitch deck exported to PDF, or an
+   in-scope piece image) with real Gemini credentials.
+2. Confirm bracketed content flows into observations — e.g. a `[Poster: …]` line surfacing as
+   a creative-concept/brand-asset observation, a `[Chart: …]` trend surfacing as a status or
+   budget signal.
+3. Spot-check a couple of plain-text files for unchanged behavior (no new noise observations).

--- a/src/drive/__tests__/interpret-contract.test.ts
+++ b/src/drive/__tests__/interpret-contract.test.ts
@@ -1,0 +1,442 @@
+/**
+ * interpret-contract.test.ts — the extraction↔interpret contract (C3 / #36).
+ *
+ * Two halves:
+ *
+ * 1. MARKER GRAMMAR (contract): extraction text — whatever produced it — must
+ *    satisfy the single grammar in extract-markers.ts. We pin BOTH producers:
+ *    the Google-native walkers (run for real over mocked API responses, same
+ *    scaffolding as extract.test.ts) and vision-shaped transcriptions (fixtures
+ *    shaped exactly like VISION_PROMPT / VISION_IMAGE_PROMPT output — the
+ *    prompts instruct an LLM, so its output can't be produced hermetically).
+ *    Producer drift (a walker emitting a marker the grammar doesn't know)
+ *    breaks this test instead of silently degrading the consumer prompts.
+ *
+ * 2. CONSUMER SPOT-CHECK (no regressions on plain text): the two consumers of
+ *    extraction text keep their exact pre-C3 behavior on a plain-text file —
+ *    the roadmap's "no interpret regressions on a text-file spot-check".
+ *      - idea-extraction: in-code prompt carries the shared grammar note and
+ *        the file text verbatim; the strict deck-type gate still drops ideas
+ *        from deck_type='other' responses.
+ *      - interpret: runs against a runPreset stub that behaves exactly like
+ *        the mock LLM driver (schema-shaped empty instance), because the real
+ *        drive.file_extraction.v1 template is a DB row (D15) — only the
+ *        code-side contract (variables in, parse/validate out) is testable.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Type, type Schema } from '@google/genai';
+
+// ── Hoisted mocks (same boundaries as extract.test.ts) ──────────────────────
+
+const {
+  googleMock,
+  buildBotOAuthClientMock,
+  docsGet,
+  presentationsGet,
+  sheetsGet,
+  sheetsBatchGet,
+} = vi.hoisted(() => ({
+  googleMock: { docs: vi.fn(), slides: vi.fn(), sheets: vi.fn() },
+  buildBotOAuthClientMock: vi.fn(),
+  docsGet: vi.fn(),
+  presentationsGet: vi.fn(),
+  sheetsGet: vi.fn(),
+  sheetsBatchGet: vi.fn(),
+}));
+
+vi.mock('googleapis', () => ({
+  google: {
+    docs: googleMock.docs,
+    slides: googleMock.slides,
+    sheets: googleMock.sheets,
+    drive: vi.fn(() => ({})),
+    auth: { OAuth2: vi.fn() },
+  },
+}));
+
+vi.mock('../../workspace', () => ({
+  buildBotOAuthClient: buildBotOAuthClientMock,
+}));
+
+const { mockConfig, CONFIG_DEFAULTS } = vi.hoisted(() => {
+  const CONFIG_DEFAULTS = { GEMINI_MAX_INPUT_CHARS: 40000 };
+  return { mockConfig: { ...CONFIG_DEFAULTS }, CONFIG_DEFAULTS };
+});
+
+vi.mock('../../config', () => ({
+  config: mockConfig,
+}));
+
+vi.mock('../../logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../client', () => ({
+  downloadFileBuffer: vi.fn(),
+}));
+
+// Mocking '../../ai' keeps the prisma-importing preset service out of the
+// unit suite (hermeticity). SchemaType must be the REAL enum — the module
+// under test builds response schemas from it at import time.
+const { llmComplete, runPresetMock } = vi.hoisted(() => ({
+  llmComplete: vi.fn(),
+  runPresetMock: vi.fn(),
+}));
+
+vi.mock('../../ai', async () => {
+  const genai = await vi.importActual<typeof import('@google/genai')>('@google/genai');
+  return {
+    defaultLlm: { name: 'gemini', complete: llmComplete },
+    DEFAULT_GEMINI_MODEL: 'gemini-3.5-flash',
+    SchemaType: genai.Type,
+    runPreset: runPresetMock,
+    // The stubs below return clean JSON; the real fence-tolerant parser
+    // lives in prompt-preset.service (not under test here).
+    parseLlmJson: (raw: string) => JSON.parse(raw),
+  };
+});
+
+import { extractGoogleDoc, extractGoogleSlides, extractGoogleSheets } from '../extract';
+import {
+  SECTION_MARKER,
+  SPEAKER_NOTES_MARKER,
+  TITLE_MARKER,
+  VISUAL_DESCRIPTION_MARKER,
+  MARKER_GRAMMAR_PROMPT_NOTE,
+  findMarkerGrammarViolations,
+} from '../extract-markers';
+import { extractIdeasFromFile } from '../idea-extraction';
+import { interpretFile } from '../interpret';
+import type { AccountCurrentState } from '../schema';
+import type { TraversedFile } from '../types';
+
+beforeEach(() => {
+  Object.assign(mockConfig, CONFIG_DEFAULTS);
+  buildBotOAuthClientMock.mockReset();
+  buildBotOAuthClientMock.mockResolvedValue({});
+  docsGet.mockReset();
+  presentationsGet.mockReset();
+  sheetsGet.mockReset();
+  sheetsBatchGet.mockReset();
+  googleMock.docs.mockReturnValue({ documents: { get: docsGet } });
+  googleMock.slides.mockReturnValue({ presentations: { get: presentationsGet } });
+  googleMock.sheets.mockReturnValue({
+    spreadsheets: { get: sheetsGet, values: { batchGet: sheetsBatchGet } },
+  });
+  llmComplete.mockReset();
+  runPresetMock.mockReset();
+});
+
+function makeFile(overrides: Partial<TraversedFile>): TraversedFile {
+  return {
+    id: 'file-1',
+    name: 'notes.txt',
+    mimeType: 'text/plain',
+    path: 'Acme / Q3 / notes.txt',
+    modifiedTime: null,
+    modifiedByEmail: null,
+    createdTime: null,
+    size: 1024,
+    isFolder: false,
+    ...overrides,
+  };
+}
+
+// ── 1. Marker grammar: producers conform ────────────────────────────────────
+
+describe('extraction marker grammar (extract-markers.ts contract)', () => {
+  it('native Slides output satisfies the grammar (## Slide N, ### Speaker notes, tables)', async () => {
+    presentationsGet.mockResolvedValue({
+      data: {
+        title: 'Acme Q3 Pitch',
+        slides: [
+          {
+            pageElements: [
+              { shape: { text: { textElements: [{ textRun: { content: 'Welcome\n' } }] } } },
+              {
+                table: {
+                  tableRows: [
+                    {
+                      tableCells: [
+                        { text: { textElements: [{ textRun: { content: 'A1' } }] } },
+                        { text: { textElements: [{ textRun: { content: 'B1' } }] } },
+                      ],
+                    },
+                  ],
+                },
+              },
+            ],
+            slideProperties: {
+              notesPage: {
+                pageElements: [
+                  { shape: { text: { textElements: [{ textRun: { content: 'a note' } }] } } },
+                ],
+              },
+            },
+          },
+          {
+            pageElements: [
+              { shape: { text: { textElements: [{ textRun: { content: 'Goals\n' } }] } } },
+            ],
+          },
+        ],
+      },
+    });
+
+    const text = await extractGoogleSlides('pres-id');
+    expect(findMarkerGrammarViolations(text)).toEqual([]);
+    expect(text.split('\n')[0]).toMatch(TITLE_MARKER);
+    expect('## Slide 1').toMatch(SECTION_MARKER);
+    expect(text).toContain('## Slide 1');
+    expect(text).toContain('## Slide 2');
+    expect(text).toContain('### Speaker notes');
+    expect(text).toContain('A1\tB1');
+  });
+
+  it('native Sheets output satisfies the grammar (## Sheet: <name>, tab rows)', async () => {
+    sheetsGet.mockResolvedValue({
+      data: {
+        properties: { title: 'Q3 Plan' },
+        sheets: [{ properties: { title: 'Forecast', sheetId: 0 } }],
+      },
+    });
+    sheetsBatchGet.mockResolvedValue({
+      data: {
+        valueRanges: [
+          {
+            range: 'Forecast!A1:Z9',
+            values: [
+              ['Month', 'Revenue'],
+              ['Jan', '$100k'],
+            ],
+          },
+        ],
+      },
+    });
+
+    const text = await extractGoogleSheets('ssheet-id');
+    expect(findMarkerGrammarViolations(text)).toEqual([]);
+    expect(text).toContain('## Sheet: Forecast');
+    expect('## Sheet: Forecast').toMatch(SECTION_MARKER);
+    expect(text).toContain('Jan\t$100k');
+  });
+
+  it('native Docs output satisfies the grammar (# title, flat paragraphs)', async () => {
+    docsGet.mockResolvedValue({
+      data: {
+        title: 'Q3 Launch Brief',
+        body: {
+          content: [
+            { paragraph: { elements: [{ textRun: { content: 'Primary contact: Bob\n' } }] } },
+          ],
+        },
+      },
+    });
+
+    const text = await extractGoogleDoc('doc-id');
+    expect(findMarkerGrammarViolations(text)).toEqual([]);
+    expect(text.split('\n')[0]).toMatch(TITLE_MARKER);
+  });
+
+  it('vision PDF transcription shape satisfies the grammar (## Page N + [Chart: …])', () => {
+    // Shaped exactly like VISION_PROMPT output (extract-vision.ts).
+    const visionPdf = [
+      '# Acme Q3 Pitch',
+      '',
+      '## Page 1',
+      'Welcome to Q3',
+      '[Chart: monthly revenue by region, peaks in March]',
+      '',
+      '## Page 2',
+      'Month\tRevenue',
+      'Jan\t$100k',
+      '[Poster: product bottle on a yellow field, bold retro typography]',
+    ].join('\n');
+
+    expect(findMarkerGrammarViolations(visionPdf)).toEqual([]);
+    expect('## Page 1').toMatch(SECTION_MARKER);
+    expect('[Chart: monthly revenue by region, peaks in March]').toMatch(VISUAL_DESCRIPTION_MARKER);
+  });
+
+  it('vision image transcription shape satisfies the grammar (# headline + [Poster: …])', () => {
+    // Shaped exactly like VISION_IMAGE_PROMPT output (extract-vision.ts).
+    const visionImage = [
+      '# Taste the Sun',
+      'Limited summer edition — in stores June 1',
+      '[Poster: product bottle on a yellow field, bold retro typography]',
+      'Logo: Acme sunburst lockup, bottom right',
+    ].join('\n');
+
+    expect(findMarkerGrammarViolations(visionImage)).toEqual([]);
+    expect(visionImage.split('\n')[0]).toMatch(TITLE_MARKER);
+  });
+
+  it('flags marker-shaped lines that are NOT in the grammar', () => {
+    const drifted = ['## Pg 3', '### Notes', '## Slide 1', '### Speaker notes'].join('\n');
+    expect(findMarkerGrammarViolations(drifted)).toEqual(['## Pg 3', '### Notes']);
+    expect('## Pg 3').not.toMatch(SECTION_MARKER);
+    expect('### Notes').not.toMatch(SPEAKER_NOTES_MARKER);
+  });
+});
+
+// ── 2a. idea-extraction spot-check (plain text — no regressions) ────────────
+
+describe('idea-extraction over plain text (spot-check)', () => {
+  const PLAIN_TEXT = [
+    'Concept round for the Acme summer brief.',
+    'Idea one: Golden Hour — a social-first campaign leaning on sunset UGC.',
+    'Idea two: Sunburst Stories — retro print series with illustrated bottles.',
+  ].join('\n');
+
+  const file = makeFile({ name: 'Acme R1 Concepts.txt', path: 'Acme / Pitch / R1 Concepts.txt' });
+
+  it('sends the file text verbatim and carries the shared marker-grammar note', async () => {
+    llmComplete.mockResolvedValue({
+      text: JSON.stringify({ deck_type: 'other', ideas: [] }),
+      driver: 'gemini',
+      model: 'gemini-3.5-flash',
+    });
+
+    await extractIdeasFromFile({ file, text: PLAIN_TEXT, accountName: 'Acme' });
+
+    expect(llmComplete).toHaveBeenCalledTimes(1);
+    const prompt = (llmComplete.mock.calls[0]![0] as { prompt: string }).prompt;
+    // Plain text rides through UNCHANGED between the """ fences.
+    expect(prompt).toContain(`"""\n${PLAIN_TEXT}\n"""`);
+    // Vision-awareness (C3): the ONE shared grammar note, verbatim.
+    expect(prompt).toContain(MARKER_GRAMMAR_PROMPT_NOTE);
+    // The strict deck-type gate is still worded as before — not loosened.
+    expect(prompt).toContain('Everything else is "other" → deck_type="other" and ideas=[]');
+    expect(prompt).toContain('Better to miss than to invent');
+  });
+
+  it('still normalizes ideas from a pitch response (behavior unchanged)', async () => {
+    llmComplete.mockResolvedValue({
+      text: JSON.stringify({
+        deck_type: 'pitch',
+        ideas: [
+          { name: '  Golden Hour ', facets: [' social-first campaign ', '', 'sunset UGC hook'] },
+          { name: '  ', facets: ['dropped — empty name'] },
+        ],
+      }),
+      driver: 'gemini',
+      model: 'gemini-3.5-flash',
+    });
+
+    const result = await extractIdeasFromFile({ file, text: PLAIN_TEXT, accountName: 'Acme' });
+    expect(result).toEqual({
+      deckType: 'pitch',
+      ideas: [{ name: 'Golden Hour', facets: ['social-first campaign', 'sunset UGC hook'] }],
+    });
+  });
+
+  it('the deck-type gate still WINS: other + ideas → no ideas', async () => {
+    llmComplete.mockResolvedValue({
+      text: JSON.stringify({
+        deck_type: 'other',
+        ideas: [{ name: 'Should be dropped', facets: ['the gate wins'] }],
+      }),
+      driver: 'gemini',
+      model: 'gemini-3.5-flash',
+    });
+
+    const result = await extractIdeasFromFile({ file, text: PLAIN_TEXT, accountName: 'Acme' });
+    expect(result).toEqual({ deckType: 'other', ideas: [] });
+  });
+});
+
+// ── 2b. interpret spot-check (mock-driver shape — plain text) ───────────────
+
+/**
+ * Replica of MockLlmDriver.emptyInstance (gemini.client.ts): a minimally-
+ * valid instance of the responseSchema. Keeping the stub derived from the
+ * SCHEMA (not hand-written JSON) pins that the mock driver's real dev-mode
+ * output still parses through interpretFile's Zod after any schema change.
+ */
+function emptyInstance(schema: Schema): unknown {
+  switch (schema.type) {
+    case Type.ARRAY:
+      return [];
+    case Type.OBJECT: {
+      const out: Record<string, unknown> = {};
+      const props = (schema.properties ?? {}) as Record<string, Schema>;
+      for (const key of schema.required ?? []) {
+        const child = props[key];
+        if (child) out[key] = emptyInstance(child);
+      }
+      return out;
+    }
+    case Type.STRING:
+      return '';
+    case Type.NUMBER:
+    case Type.INTEGER:
+      return 0;
+    case Type.BOOLEAN:
+      return false;
+    default:
+      return null;
+  }
+}
+
+describe('interpret over plain text via the mock-driver shape (spot-check)', () => {
+  const PLAIN_TEXT = 'Kickoff notes: launch shifted to June 1. Maya is creative lead.';
+
+  function interpretInput(text: string) {
+    return {
+      file: makeFile({ name: 'kickoff.txt', path: 'Acme / kickoff.txt' }),
+      text,
+      accountName: 'Acme',
+      accountCurrentState: {} as AccountCurrentState,
+      campaignName: null,
+      campaignCurrentState: null,
+      knownCampaigns: ['Summer Launch'],
+    };
+  }
+
+  beforeEach(() => {
+    runPresetMock.mockImplementation(async (opts: { responseSchema?: Schema }) => ({
+      text: JSON.stringify(opts.responseSchema ? emptyInstance(opts.responseSchema) : []),
+      driver: 'mock',
+      model: 'gemini-3.5-flash',
+      prompt: '(rendered by preset)',
+    }));
+  });
+
+  it('passes plain file text through to the preset UNCHANGED (no truncation)', async () => {
+    await interpretFile(interpretInput(PLAIN_TEXT));
+
+    expect(runPresetMock).toHaveBeenCalledTimes(1);
+    const opts = runPresetMock.mock.calls[0]![0] as {
+      key: string;
+      variables: Record<string, unknown>;
+    };
+    expect(opts.key).toBe('drive.file_extraction.v1');
+    expect(opts.variables['file_text']).toBe(PLAIN_TEXT);
+  });
+
+  it('parses the mock-driver stub: empty observations, deck_type falls back to other', async () => {
+    const result = await interpretFile(interpretInput(PLAIN_TEXT));
+    // emptyInstance emits deck_type:'' — an invalid enum value that the
+    // .catch('other') in PerFileResponseSchema must absorb, exactly as the
+    // real mock driver's dev-mode output does.
+    expect(result).toEqual({
+      account: [],
+      campaign: [],
+      deckType: 'other',
+      truncated: false,
+      driver: 'mock',
+    });
+  });
+
+  it('still truncates once at GEMINI_MAX_INPUT_CHARS (unchanged by C3)', async () => {
+    mockConfig.GEMINI_MAX_INPUT_CHARS = 10;
+    const result = await interpretFile(interpretInput(PLAIN_TEXT));
+
+    expect(result.truncated).toBe(true);
+    const opts = runPresetMock.mock.calls[0]![0] as { variables: Record<string, unknown> };
+    const sent = opts.variables['file_text'] as string;
+    expect(sent.startsWith(PLAIN_TEXT.slice(0, 10))).toBe(true);
+    expect(sent).toContain(`[TRUNCATED: ${PLAIN_TEXT.length - 10} chars omitted]`);
+  });
+});

--- a/src/drive/extract-markers.ts
+++ b/src/drive/extract-markers.ts
@@ -1,0 +1,72 @@
+/**
+ * extract-markers.ts — the extraction-text marker grammar (issue C3 / #36).
+ *
+ * Single source of truth for what extraction text may contain, shared by:
+ *   - the PRODUCERS — extract.ts walkers and extract-vision.ts prompts
+ *     (their header docs point here; the contract test pins conformance)
+ *   - the CONSUMERS — idea-extraction.ts embeds MARKER_GRAMMAR_PROMPT_NOTE
+ *     in its in-code prompt; the drive.file_extraction.v1 DB prompt row
+ *     mirrors the same note (delivered via the staff prompt-authoring
+ *     path — per D15 that prompt is deliberately NOT code-seeded)
+ *   - the CONTRACT TEST — __tests__/interpret-contract.test.ts checks that
+ *     native-walker output and vision-shaped output both satisfy this
+ *     grammar, so producer drift breaks a test instead of silently
+ *     degrading the consumers
+ *
+ * The grammar (one marker per line; flat plain text everywhere else):
+ *   "# <title>"          — document/deck/workbook title, or an image's headline
+ *   "## Page N"          — vision PDF page           ┐ EQUIVALENT section
+ *   "## Slide N"         — native Slides slide       ├ boundaries — a PDF's
+ *   "## Sheet: <name>"   — native Sheets tab         ┘ pages are a deck's slides
+ *   "### Speaker notes"  — a slide's speaker-notes section
+ *   tab-separated cells  — table rows, one row per line
+ *   "[<one-line description>]" — vision's description of a chart, diagram,
+ *     poster, or creative image. OBSERVED CONTENT, not formatting noise.
+ *
+ * The Page/Slide/Sheet divergence is reconciled HERE and in the consumers,
+ * never in the extractors: a PDF genuinely has pages, so the extractor must
+ * not fake slide numbers on it. Keep this module behavior-free — regexes and
+ * prompt text only; the extractors do not consult it at runtime.
+ */
+
+/** "# <title>" — first line of most extractions; also an image's headline. */
+export const TITLE_MARKER = /^# \S.*$/;
+
+/**
+ * "## Page N" | "## Slide N" | "## Sheet: <name>" — the three EQUIVALENT
+ * section boundaries. Which one appears depends only on the extractor that
+ * produced the text, not on the content's meaning.
+ */
+export const SECTION_MARKER = /^## (?:Page \d+|Slide \d+|Sheet: \S.*)$/;
+
+/** "### Speaker notes" — the only three-hash marker the grammar allows. */
+export const SPEAKER_NOTES_MARKER = /^### Speaker notes$/;
+
+/** "[<one-line visual/creative description>]" — a whole-line bracketed note. */
+export const VISUAL_DESCRIPTION_MARKER = /^\[.+\]$/;
+
+/**
+ * Prompt-ready description of the grammar for the consumer prompts.
+ * idea-extraction.ts embeds this verbatim; the drive.file_extraction.v1
+ * DB row carries a matching note (see the C3 PR body / docs note).
+ */
+export const MARKER_GRAMMAR_PROMPT_NOTE = `It is machine-extracted (Workspace API walkers for Google-native files; Gemini vision transcription for PDFs and images) and may contain structural markers: "# <title>"; "## Page N" / "## Slide N" / "## Sheet: <name>" — EQUIVALENT section boundaries (a PDF's pages are a deck's slides; treat them identically); "### Speaker notes"; tab-separated table rows; and one-line [bracketed] descriptions of charts, diagrams, and creative visuals, e.g. [Chart: monthly revenue by region, peaks in March] or [Poster: product bottle on a yellow field, bold retro typography]. Bracketed lines are OBSERVED CONTENT — what the extractor saw on the rendered page — not formatting noise.`;
+
+/**
+ * Return the marker-SHAPED lines that don't conform to the grammar: any
+ * "## " line that isn't one of the three section boundaries, and any
+ * "### " line that isn't the speaker-notes marker. Plain content lines
+ * (including "# <title>" — any text is a valid title) never violate.
+ * Test-only helper; production code never validates extraction text.
+ */
+export function findMarkerGrammarViolations(text: string): string[] {
+  const violations: string[] = [];
+  for (const line of text.split('\n')) {
+    if (line.startsWith('### ')) {
+      if (!SPEAKER_NOTES_MARKER.test(line)) violations.push(line);
+    } else if (line.startsWith('## ')) {
+      if (!SECTION_MARKER.test(line)) violations.push(line);
+    }
+  }
+  return violations;
+}

--- a/src/drive/extract-vision.ts
+++ b/src/drive/extract-vision.ts
@@ -32,7 +32,12 @@
  *
  * Output contract: the SAME flat marked-up text the Google-native
  * walkers emit (`# Title`, `## <section>` markers, tab-separated table
- * rows) so downstream interpret.ts consumes it unchanged.
+ * rows) so downstream interpret.ts consumes it unchanged. The full
+ * marker grammar — including `## Page N` as the PDF-side equivalent of
+ * `## Slide N`, and `[bracketed]` one-line visual descriptions — lives
+ * in extract-markers.ts (issue C3 / #36); the contract test pins that
+ * vision-shaped output satisfies it. Keep the prompts below and that
+ * grammar in lockstep.
  */
 
 import { config } from '../config';

--- a/src/drive/extract.ts
+++ b/src/drive/extract.ts
@@ -38,6 +38,12 @@
  * markers (slide titles, sheet names, doc title) so downstream Gemini sees
  * structural signal — slide boundaries, speaker notes, sheet boundaries —
  * not just a wall of text.
+ *
+ * The marker grammar the walkers emit ("# <title>", "## Slide N",
+ * "## Sheet: <name>", "### Speaker notes", tab-separated table rows) is
+ * documented in extract-markers.ts — the single source of truth shared
+ * with extract-vision.ts, the consumer prompts, and the contract test
+ * (issue C3 / #36). Keep the walkers and that grammar in lockstep.
  */
 
 import crypto from 'node:crypto';

--- a/src/drive/idea-extraction.ts
+++ b/src/drive/idea-extraction.ts
@@ -27,6 +27,7 @@ import { z } from 'zod';
 import { SchemaType, type ResponseSchema } from '../ai';
 import { defaultLlm, parseLlmJson, DEFAULT_GEMINI_MODEL } from '../ai';
 import { logger } from '../logger';
+import { MARKER_GRAMMAR_PROMPT_NOTE } from './extract-markers';
 import type { TraversedFile } from './types';
 
 const MODEL = DEFAULT_GEMINI_MODEL;
@@ -102,6 +103,9 @@ FILE CONTENT:
 """
 ${args.fileText}
 """
+
+NOTE ON FILE CONTENT: ${MARKER_GRAMMAR_PROMPT_NOTE}
+For idea mining that means a [bracketed] creative visual can itself be the idea or carry its facets — a described key visual, poster, or chart is content the deck's authors presented, exactly like the copy around it. Do NOT discard bracketed lines, and treat "## Page N" in a PDF export the same as "## Slide N" in a native deck. The markers change nothing about the gate below: what counts as a pitch or creative-review deck is unchanged.
 
 STEP 1 — WHAT KIND OF DECK IS THIS?  (deck_type)
 Ideas live in exactly TWO kinds of artifact, and NOWHERE else:


### PR DESCRIPTION
Closes #36 (issue C3). Stacked on #47 (`feat/c2-ungate-images`) — merge that first. Closes Phase C.

C1/C2 made extraction vision-rich (`## Page N` sections, `[bracketed]` one-line descriptions of charts/posters/creative), but both consumers of extraction text were written for old flat native text — vision's differentiating signal could be discarded as formatting noise. This PR reconciles the contract on the consumer side; **no extractor behavior changes, no schema changes, no gate-semantics changes**.

## What's in the repo diff

- **`src/drive/extract-markers.ts`** (new) — the single documented marker grammar for extraction text: `# <title>`; `## Page N` / `## Slide N` / `## Sheet: <name>` as **equivalent section boundaries** (page≈slide reconciled here and in the consumers — the extractor keeps emitting real page numbers for PDFs, never fake slide numbers); `### Speaker notes`; tab-separated table rows; `[bracketed]` one-line visual descriptions. Exports a prompt-ready note (embedded by the idea prompt, mirrored by the DB interpret prompt) and a test-only conformance checker. Both extractor headers now point here.
- **`src/drive/idea-extraction.ts`** — `buildPrompt` embeds the shared grammar note plus: a described creative visual can itself be the idea or carry its facets; do NOT discard bracketed lines; `## Page N` in a PDF export ≡ `## Slide N` in a native deck. **The strict deck-type gate is unchanged** (precision over recall stays).
- **`src/drive/__tests__/interpret-contract.test.ts`** (new, first interpret/contract test) — (a) native-walker output AND vision-shaped output both satisfy the shared grammar (drift breaks the test); (b) plain-text spot-check: idea-extraction still sends file text verbatim, still normalizes ideas, the `other` gate still wins; interpret still passes `file_text` verbatim, truncates once at `GEMINI_MAX_INPUT_CHARS`, and parses the mock-driver stub (`deck_type` falls back to `'other'` via `.catch`). 85/85 tests green, `tsc` clean on the diff.
- **`docs/file-extraction-prompt-vision-note.md`** — the prompt-text delta for the DB row + apply/spot-check instructions.

## Not in the repo: the `drive.file_extraction.v1` prompt update (manual apply)

Per D15 the interpret prompt is a **staff-edited `prompt_presets` DB row** — deliberately not code-seeded, so this PR can't apply or unit-test it. Apply via gub-admin → prompt presets → `drive.file_extraction.v1`, **keeping the key `v1`** (edit in place; a key change would require an `interpret.ts` edit).

Insert this block **between the `Contents:` `"""` block and `TASK`**:

```text
  NOTE ON CONTENTS — the text above is machine-extracted (Workspace API
  walkers for Google-native files; Gemini vision transcription for PDFs
  and images). It may contain structural markers:
    - "# <title>" — the document/deck/workbook title (or an image's headline)
    - "## Page N" / "## Slide N" / "## Sheet: <name>" — EQUIVALENT section
      boundaries: which one appears depends only on the file type (a PDF's
      pages are a deck's slides). Treat them identically.
    - "### Speaker notes" — a slide's speaker notes
    - tab-separated table rows
    - one-line [bracketed] descriptions of charts, diagrams, images, and
      creative visuals, e.g. [Chart: monthly revenue by region, peaks in
      March] or [Poster: product bottle on a yellow field, bold retro
      typography]
  [Bracketed] lines are OBSERVED CONTENT — what the extractor saw on the
  rendered page — not formatting noise. Mine them for substance exactly like
  the surrounding text: a chart's stated trend can be a status or budget
  signal, a described poster or key visual can reveal a campaign's creative
  concept, positioning, or brand assets. A bracketed visual description
  passes the POSITIVE TEST below the same way the equivalent sentence of
  body copy would — judge it by what it says about THIS client's work.
```

<details>
<summary>Full updated template (current prod-copy row + the block above) — copy-paste ready</summary>

```text
You are reading one file from a client's shared Google Drive at an ad agency. What you extract feeds the living dossier we keep on this client and their campaigns — report what this file reveals.

ACCOUNT (the client)
  Name: {{account_name}}

FILE
  Path: {{file_path}}
  Filed under campaign: {{campaign_name}}
  Last modified: {{modified_time}} by {{modified_by}}

  Contents:
  """
  {{file_text}}
  """

  NOTE ON CONTENTS — the text above is machine-extracted (Workspace API
  walkers for Google-native files; Gemini vision transcription for PDFs
  and images). It may contain structural markers:
    - "# <title>" — the document/deck/workbook title (or an image's headline)
    - "## Page N" / "## Slide N" / "## Sheet: <name>" — EQUIVALENT section
      boundaries: which one appears depends only on the file type (a PDF's
      pages are a deck's slides). Treat them identically.
    - "### Speaker notes" — a slide's speaker notes
    - tab-separated table rows
    - one-line [bracketed] descriptions of charts, diagrams, images, and
      creative visuals, e.g. [Chart: monthly revenue by region, peaks in
      March] or [Poster: product bottle on a yellow field, bold retro
      typography]
  [Bracketed] lines are OBSERVED CONTENT — what the extractor saw on the
  rendered page — not formatting noise. Mine them for substance exactly like
  the surrounding text: a chart's stated trend can be a status or budget
  signal, a described poster or key visual can reveal a campaign's creative
  concept, positioning, or brand assets. A bracketed visual description
  passes the POSITIVE TEST below the same way the equivalent sentence of
  body copy would — judge it by what it says about THIS client's work.

TASK
  For each observation, emit:
    - text: a concise statement of what the file reveals about the entity. One sentence, no preamble. Be specific (names, dates, decisions, positioning) rather than abstract ("contains information").
    - reasoning: one sentence citing what in the file implies the observation.
    - confidence: 0.0–1.0 — your subjective certainty.
    - entity_campaign_name (campaign[] obs only — null/omitted on account[]): the campaign this observation is about. Prefer the exact names listed in WHERE YOU ARE below, which also says when to tag.

  Be liberal. You are a marketing and agency domain expert — trust your judgment about what matters. Notable things include: brand positioning, audience direction, creative concepts, messaging, team members and roles, stakeholder relationships, milestones, deliverables in flight, decisions made or in progress, risks, budget signals, status changes, competitive signals, scheduling. Capture job numbers, PO numbers, and estimate numbers VERBATIM wherever they appear — they are authoritative identifiers of the work.

  AGENCY FILTER — Anomaly is the agency producing this work. Observations are about the CLIENT (the account / campaigns named above), NOT about Anomaly itself.

    HARD GATE — agency-internal documents return EMPTY arrays.

      Some files stored in a client Drive are not actually about the client at all. They are internal Anomaly documents that happen to live in this folder. Examples:
        - Agency training materials, onboarding decks, role-and-rank descriptions
        - Intern programs, mentorship structures, career paths
        - Internal team structures, account team org charts that apply to all clients
        - Agency-wide capabilities decks, services menus, "how we work" docs
        - Methodology / process / framework overviews (e.g. IAT model descriptions, generic creative process docs)
        - Anomaly's own brand guidelines, internal style guides, agency identity
        - Vendor / partner / tool stack documentation

      If the file is primarily one of the above, EMIT EMPTY ARRAYS for both account and campaign. Do not extract "facts" from it. The fact that it sits in {{account_name}}'s Drive does not make its content about {{account_name}}.

    POSITIVE TEST — every emitted observation MUST mention at least one of:
      - The specific client / brand named at ACCOUNT.Name above
      - A specific campaign (the file's owner, a campaign from the WHERE YOU ARE list, or a freshly-named campaign in the source)
      - A specific person assigned to THIS engagement (named individual + their role for THIS client)
      - A specific decision, deliverable, milestone, risk, or situational fact about THIS work
      - A specific creative concept, positioning, or strategy for THIS brand/campaign

      If an observation would still be true substituting ANY OTHER client's name in for {{account_name}}, it's agency boilerplate — DROP IT.

    DROP EXAMPLES (actual slip-throughs from prior scans — use as anchor cases):
      - "Anomaly has a formal training curriculum for its account interns, covering fundamentals for the Account Executive role"
      - "The agency's account team structure includes roles such as Account Executive, Account Supervisor, Account Director, Business Director, and Group Business Head"
      - "Anomaly operates with an Integrated Agency Team (IAT) model, where it leads creative and strategic vision while collaborating with PR, Media, Experiential, and Influencer Marketing partners"
      - "Anomaly has worked with brands like Coca-Cola and Diageo"
      - "Anomaly's standard creative process involves discovery, ideation, and execution phases"

    KEEP EXAMPLES (these pass the positive test — specific-to-this-engagement signal):
      - "Maya from Anomaly is the creative lead on {{campaign_name}}"
      - "Anomaly proposed a bespoke immersion week specifically for {{account_name}}'s brand refresh"
      - "Anomaly is partnering with Hill+Knowlton for PR on the {{campaign_name}} launch"
      - "{{account_name}}'s primary day-to-day contact at Anomaly is Sam Chen"

    Heuristic of last resort: if the same sentence would appear unchanged in Anomaly's pitch deck or capabilities overview regardless of which client this work is for, DROP IT. A sentence that explicitly references Anomaly's general practice only as a contrast for what's being done specifically for THIS client (e.g. "Anomaly is using a 4-week cadence here vs. their usual 6-week") may be kept.

    When ambiguous, default to dropping. Missing a borderline non-standard observation is an acceptable cost — it will likely surface again in a later file with clearer context. Admitting boilerplate is more costly: it pollutes the canonical client snapshot and degrades every future read.

  LOCATION CONTEXT — When this file's parent folder (from the Path above) appears to be a meaningful collection — Fonts, Brand Assets, Briefs, References, Finals, Working Files, Decks, Transcripts, Contracts, Visual Identity, Type, Logos, Photography, and the like — emit an additional observation that names the folder by its full path. Phrase it as a fact about the entity, e.g. "The Diageo Spring Pitch's fonts live at /Diageo/Diageo Spring Pitch/Brand Assets/Fonts" or "Acme's reusable brand assets are at /Acme/Brand Assets". Use the file's actual path verbatim — do not guess or abbreviate. One folder-context observation per file is plenty; don't emit it for files in generic / non-collection folders (a status doc inside the project root, a one-off PDF in Inbox, etc.). Location-context observations are exempt from the per-observation positive test above as long as the folder is inside this client's Drive tree.

    Extract the assets themselves too, not just where they live. When this file's name, path, or contents reveal a concrete brand asset — a typeface, a color palette, a logo variant or lockup, a photography style, a tagline — emit that as its own observation, phrased as a fact about the entity: "Chevy's brand typeface is Louis", "The Spring Pitch palette is navy and safety orange per the brand guidelines". The file's own name and path count as evidence: a font license sitting at /Chevy/Brand Assets/Fonts/Louis establishes the typeface even if its text never names it.

  WHERE YOU ARE — the file's folder position decides how campaign observations route.

    Names you may tag, exactly as written:
      {{known_campaigns_json}}

    IN A CAMPAIGN'S SPACE ("Filed under campaign" is set): you are inside that campaign's folder tree, and the campaign is already decided. The list above holds that campaign and its pieces. Your campaign[] observations are about THAT campaign — its work, its pieces, its schedule, its people; tag with the exact name from the list when one fits. If an observation is clearly about another campaign and not this one, drop the observation. Never re-assign the campaign yourself.

    IN ACCOUNT SPACE ("Filed under campaign" is (n/a)): you are above the campaign folders, scanning at account level AND known-campaign level. The list above holds every campaign known for this account. Emit account[] observations for brand-level content. When content is specifically about a campaign in the list, emit a campaign[] observation tagged with its name EXACTLY as written. A campaign named in content that is NOT in the list is account-level context (the brand's history or its pipeline) — emit it as account[], no tag. Campaigns are only ever created from folders, never from mentions.

  WHAT GOES WHERE — account[] vs campaign[]: ask "is this claim about the brand at large, or about one specific campaign's work?"
    - account[]: industry, positioning, primary contacts, team structure, account-wide assets and collections, portfolio strategy, the history and heritage of past campaigns, speculative future concepts not yet committed.
    - campaign[]: one campaign's execution — creative, deliverables, schedule, milestones, roles, budget signals, decisions, risks.
    - A campaign for a DIFFERENT client (a comparison or reference) is not about {{account_name}} — don't extract it at all, unless it is used as a material reference.


  DECK TYPE — additionally classify THIS FILE as a whole (one value for the file, independent of the observations):

    - "pitch"           — a PITCH DECK: creative concepts proposed to win or answer a brief (new business, an RFP response, a concept round against a client brief).
    - "creative_review" — a CREATIVE REVIEW DECK: creative work/concepts presented internally or to the client for feedback or approval during development.
    - "other"           — everything else: briefs and RFPs that only state the ask, strategy/planning decks, media plans, timelines, budgets, status/wrap/recap decks, final delivered creative, case studies, capabilities/credentials decks, SOPs, meeting notes, spreadsheets, contracts, agency-internal material.

    Weight the file name and path — agency naming is dense with intent ("Pitch", "Concepts", "Round 1/2", "Creative Review", "Territories", "R&D") — but CONFIRM with the content; filenames lie. If the file does not actually PRESENT proposed creative ideas for a decision, it is "other".

    This classification gates a downstream idea-extraction step that mines pitch ideas into institutional memory — precision matters more than recall there, so when unsure, "other".

  Skip purely administrative content (calendar invites, signature confirmations, blank templates, sharing notifications). Otherwise default to emitting observations that pass the positive test — empty arrays should be rare for genuinely client-focused files, AND empty arrays should be expected for agency-internal files (per the hard gate above).

  Downstream steps dedupe across files, classify into field_changes vs notes, and compare against the entity's current state. Don't filter here — just extract.
```

</details>

⚠️ The template above was assembled against the `gub_prod_copy` snapshot of the row (last updated 2026-07-15). If staff edited the prod row since, re-anchor the block on the `Contents`/`TASK` boundary instead of pasting the full text over their edits.

## Manual dev spot-check (after the DB prompt is applied)

The real interpret behavior change is untestable from this repo (prompt = DB row; the mock driver is gated off vision), so after applying:

1. Scan a vision-heavy file with real Gemini credentials (image-set pitch deck exported to PDF, or an in-scope piece image) — dev recipe: dev-secrets + prod-copy DB, as used for the C1/C2 evals.
2. Confirm bracketed content flows into observations — a `[Poster: …]` line surfacing as a creative-concept/brand-asset observation, a `[Chart: …]` trend surfacing as a status/budget signal.
3. Spot-check a couple of plain-text files for unchanged behavior (no new noise observations).
