### PR TITLE
feat(scan): emit candidate insights from per-entity distillation (D2)

### DIFF
--- a/src/backfill/run.ts
+++ b/src/backfill/run.ts
@@ -314,6 +314,22 @@ async function runBackfillInner(args: Args): Promise<BackfillRunResult> {
           `     distill: ${result.distillResult.proposalsCreated} field changes / ${result.distillResult.notesWritten} notes`,
         );
       }
+      // D2 (#38): candidate insights assembled from the distilled output.
+      // In-memory only — the acceptance surface until D4 persists them.
+      if (result.candidates.length > 0) {
+        log(`     candidates: ${result.candidates.length} insight candidate(s) (not persisted — D2)`);
+        for (const c of result.candidates) {
+          const scope =
+            c.entityType === 'account'
+              ? `account ${c.entityId}`
+              : `campaign(${c.entityStatus}) ${c.entityId}`;
+          const text = c.text.length > 100 ? `${c.text.slice(0, 100)}…` : c.text;
+          log(`       · [${c.origin}] "${text}"`);
+          log(
+            `         ${scope}  ·  account ${c.accountId}  ·  ${c.sourceFileIds.length} source file(s)  ·  confidence ${c.confidence.toFixed(2)}`,
+          );
+        }
+      }
       log('     ┌── status_markdown ──────────────────');
       for (const line of result.synthesizedMarkdown.split('\n')) {
         log(`     │ ${line}`);

--- a/src/drive/__tests__/candidate-insight.test.ts
+++ b/src/drive/__tests__/candidate-insight.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  CandidateInsightSchema,
+  NOTE_DEFAULT_CONFIDENCE,
+  toCandidateInsights,
+  type CandidateDistillResult,
+  type CandidateTarget,
+} from '../candidate-insight';
+
+const ACCOUNT_ID = 'acct_1';
+
+const accountTarget: CandidateTarget = {
+  accountId: ACCOUNT_ID,
+  entityType: 'account',
+  entityStatus: 'account',
+  entityId: ACCOUNT_ID,
+  campaignFolderId: null,
+  entityName: 'Acme Corp',
+};
+
+const existingCampaignTarget: CandidateTarget = {
+  accountId: ACCOUNT_ID,
+  entityType: 'campaign',
+  entityStatus: 'existing',
+  entityId: 'camp_9',
+  campaignFolderId: 'folder_camp_9',
+  entityName: 'Spring Launch',
+};
+
+const newCampaignTarget: CandidateTarget = {
+  accountId: ACCOUNT_ID,
+  entityType: 'campaign',
+  entityStatus: 'new',
+  entityId: null,
+  campaignFolderId: 'folder_new_1',
+  entityName: 'Fall Teaser',
+};
+
+const emptyDistill: CandidateDistillResult = { field_changes: [], notes: [] };
+
+const oneOfEach: CandidateDistillResult = {
+  field_changes: [
+    {
+      field: 'budget',
+      proposed_value: '50000',
+      reasoning: 'stated in the brief',
+      source_file_ids: ['file_a', 'file_b'],
+      confidence: 0.85,
+    },
+  ],
+  notes: [{ text: 'Client wants a June launch.', source_file_ids: ['file_c'] }],
+};
+
+describe('toCandidateInsights — mapping', () => {
+  it('maps a field_change to a candidate with rendered text and its own confidence', () => {
+    const [candidate] = toCandidateInsights(existingCampaignTarget, {
+      ...emptyDistill,
+      field_changes: oneOfEach.field_changes,
+    });
+    expect(candidate).toEqual({
+      accountId: ACCOUNT_ID,
+      entityType: 'campaign',
+      entityId: 'camp_9',
+      entityStatus: 'existing',
+      text: 'budget → 50000 (stated in the brief)',
+      sourceFileIds: ['file_a', 'file_b'],
+      confidence: 0.85,
+      origin: 'field_change',
+    });
+  });
+
+  it('renders a null proposed_value as (null)', () => {
+    const [candidate] = toCandidateInsights(existingCampaignTarget, {
+      ...emptyDistill,
+      field_changes: [{ ...oneOfEach.field_changes[0]!, proposed_value: null }],
+    });
+    expect(candidate!.text).toBe('budget → (null) (stated in the brief)');
+  });
+
+  it('maps a note to a candidate with the default confidence', () => {
+    const [candidate] = toCandidateInsights(existingCampaignTarget, {
+      ...emptyDistill,
+      notes: oneOfEach.notes,
+    });
+    expect(candidate).toEqual({
+      accountId: ACCOUNT_ID,
+      entityType: 'campaign',
+      entityId: 'camp_9',
+      entityStatus: 'existing',
+      text: 'Client wants a June launch.',
+      sourceFileIds: ['file_c'],
+      confidence: NOTE_DEFAULT_CONFIDENCE,
+      origin: 'note',
+    });
+  });
+
+  it('emits field_changes and notes together, field_changes first', () => {
+    const candidates = toCandidateInsights(existingCampaignTarget, oneOfEach);
+    expect(candidates.map((c) => c.origin)).toEqual(['field_change', 'note']);
+  });
+});
+
+describe('toCandidateInsights — scope from the Target', () => {
+  it('account target: entityId is the account id, no entityStatus', () => {
+    const [candidate] = toCandidateInsights(accountTarget, oneOfEach);
+    expect(candidate!.entityType).toBe('account');
+    expect(candidate!.entityId).toBe(ACCOUNT_ID);
+    expect(candidate!.entityStatus).toBeUndefined();
+    expect(candidate!.accountId).toBe(ACCOUNT_ID);
+  });
+
+  it('account target on a campaign-scoped scan (Target.entityId null) still anchors to accountId', () => {
+    const [candidate] = toCandidateInsights({ ...accountTarget, entityId: null }, oneOfEach);
+    expect(candidate!.entityId).toBe(ACCOUNT_ID);
+  });
+
+  it('existing campaign: entityId is the matched campaign id', () => {
+    const [candidate] = toCandidateInsights(existingCampaignTarget, oneOfEach);
+    expect(candidate!.entityType).toBe('campaign');
+    expect(candidate!.entityStatus).toBe('existing');
+    expect(candidate!.entityId).toBe('camp_9');
+  });
+
+  it('new campaign candidate: entityId is the campaign folder ref', () => {
+    const [candidate] = toCandidateInsights(newCampaignTarget, oneOfEach);
+    expect(candidate!.entityType).toBe('campaign');
+    expect(candidate!.entityStatus).toBe('new');
+    expect(candidate!.entityId).toBe('folder_new_1');
+  });
+
+  it('phantom new candidate (no folder id) emits nothing and warns', () => {
+    const warn = vi.fn();
+    const candidates = toCandidateInsights(
+      { ...newCampaignTarget, campaignFolderId: null },
+      oneOfEach,
+      warn,
+    );
+    expect(candidates).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('phantom'));
+  });
+
+  it('piece target emits nothing (pieces are the idea-extraction tier)', () => {
+    const candidates = toCandidateInsights(
+      {
+        accountId: ACCOUNT_ID,
+        entityType: 'piece',
+        entityStatus: 'piece',
+        entityId: 'piece_1',
+        campaignFolderId: null,
+        entityName: 'Hero video',
+      },
+      oneOfEach,
+    );
+    expect(candidates).toEqual([]);
+  });
+});
+
+describe('toCandidateInsights — provenance and validation (A1)', () => {
+  it('drops a candidate with empty sourceFileIds and warns instead of emitting', () => {
+    const warn = vi.fn();
+    const candidates = toCandidateInsights(
+      existingCampaignTarget,
+      {
+        field_changes: [{ ...oneOfEach.field_changes[0]!, source_file_ids: [] }],
+        notes: oneOfEach.notes,
+      },
+      warn,
+    );
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]!.origin).toBe('note');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('empty sourceFileIds'));
+  });
+
+  it('drops a note with empty text without throwing', () => {
+    const warn = vi.fn();
+    const candidates = toCandidateInsights(
+      existingCampaignTarget,
+      { ...emptyDistill, notes: [{ text: '', source_file_ids: ['file_c'] }] },
+      warn,
+    );
+    expect(candidates).toEqual([]);
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe('CandidateInsightSchema', () => {
+  const valid = {
+    accountId: ACCOUNT_ID,
+    entityType: 'campaign',
+    entityId: 'camp_9',
+    entityStatus: 'existing',
+    text: 'Client wants a June launch.',
+    sourceFileIds: ['file_c'],
+    confidence: 0.5,
+    origin: 'note',
+  };
+
+  it('accepts a valid candidate', () => {
+    expect(() => CandidateInsightSchema.parse(valid)).not.toThrow();
+  });
+
+  it('rejects empty text', () => {
+    expect(() => CandidateInsightSchema.parse({ ...valid, text: '' })).toThrow();
+  });
+
+  it('rejects empty sourceFileIds', () => {
+    expect(() => CandidateInsightSchema.parse({ ...valid, sourceFileIds: [] })).toThrow();
+  });
+
+  it('rejects out-of-range confidence', () => {
+    expect(() => CandidateInsightSchema.parse({ ...valid, confidence: 1.2 })).toThrow();
+    expect(() => CandidateInsightSchema.parse({ ...valid, confidence: -0.1 })).toThrow();
+  });
+});

--- a/src/drive/candidate-insight.ts
+++ b/src/drive/candidate-insight.ts
@@ -1,0 +1,172 @@
+// D2 (#38): candidate-insight assembly over the scan-core distillation
+// output. Pure post-processing — the Stage-2 attributor already decided
+// each entity's scope (the Target), and distillation already emitted
+// notes + field_changes with provenance; this module just reshapes the
+// two into the D1/B3 insight contract so D3 (embed → retrieve →
+// reconcile) consumes candidates unchanged. NO LLM call, NO persistence,
+// NO embedding here — those are D4/D3.
+//
+// Kept out of schema.ts (mirrored/lockstep with gcp-universal-backend)
+// and structured-output.ts (LLM response schemas) on purpose: the
+// candidate shape is a consumer contract, not a prompt contract.
+import { z } from 'zod';
+
+/**
+ * Notes in drive.distillation.v1 carry no confidence — only
+ * field_changes do. Default the notes half to a deliberately neutral
+ * value rather than fabricating high confidence; adding a real
+ * confidence to the notes output is a later prompt edit, not D2.
+ */
+export const NOTE_DEFAULT_CONFIDENCE = 0.5;
+
+/**
+ * The D1/B3 insight-candidate contract.
+ *
+ * - `accountId` — owning account = RLS/scope anchor (D1 insights.account_id).
+ * - `entityId` — account id | campaign id (existing) | campaignFolderId
+ *   (new candidate). A NEW campaign has no DB row yet, so its entityId is
+ *   a Drive folder ref (decoupled external-id pattern, same as the ideas
+ *   tier) — D3/D4 resolve it to a campaign row at reconcile/apply time.
+ * - `sourceFileIds` — provenance, never empty (the A1 lesson).
+ * - `confidence` — 0..1 here; convert to Decimal(3,2) only at D4 persist.
+ */
+export const CandidateInsightSchema = z.object({
+  accountId: z.string(),
+  entityType: z.enum(['account', 'campaign']),
+  entityId: z.string(),
+  entityStatus: z.enum(['existing', 'new']).optional(),
+  text: z.string().min(1),
+  sourceFileIds: z.array(z.string()).min(1),
+  confidence: z.number().min(0).max(1),
+  origin: z.enum(['field_change', 'note']),
+});
+
+export type CandidateInsight = z.infer<typeof CandidateInsightSchema>;
+
+// Structural mirrors of the scan-core shapes (Target in process-batch.ts,
+// runDistillation's return in persist.ts) so this module stays free of
+// prisma/scan imports and the unit suite stays hermetic.
+
+export interface CandidateTarget {
+  /** Owning account id (EntityCtx.accountId) — always set, even on campaign scans. */
+  accountId: string;
+  entityType: 'account' | 'campaign' | 'piece';
+  entityStatus: 'account' | 'existing' | 'new' | 'piece';
+  /** Account/campaign DB id; null for new candidates (no row yet). */
+  entityId: string | null;
+  /** Campaign-root folder id — the external ref for NEW candidates. */
+  campaignFolderId: string | null;
+  entityName: string;
+}
+
+export interface DistilledFieldChange {
+  field: string;
+  proposed_value?: string | null | undefined;
+  reasoning: string;
+  source_file_ids: string[];
+  confidence: number;
+}
+
+export interface DistilledNote {
+  text: string;
+  source_file_ids: string[];
+}
+
+export interface CandidateDistillResult {
+  field_changes: DistilledFieldChange[];
+  notes: DistilledNote[];
+}
+
+type CandidateScope = Pick<CandidateInsight, 'entityType' | 'entityId' | 'entityStatus'>;
+
+// The Target IS the entity slot — scope is read off it, never re-derived.
+// Returns null when the target can't anchor a candidate:
+//   - pieces: distillation is skipped for them upstream (markdown-only);
+//     piece/idea insights are the separate idea-extraction tier.
+//   - phantom new candidates (campaignFolderId null): no stable external
+//     ref exists until persist creates the row — nothing D3 could
+//     reconcile against.
+function resolveScope(target: CandidateTarget, warn: (message: string) => void): CandidateScope | null {
+  if (target.entityType === 'account') {
+    return { entityType: 'account', entityId: target.accountId };
+  }
+  if (target.entityType === 'campaign') {
+    if (target.entityStatus === 'new') {
+      if (!target.campaignFolderId) {
+        warn(
+          `candidates: skipped for phantom candidate "${target.entityName}" — no campaignFolderId to anchor entityId`,
+        );
+        return null;
+      }
+      return { entityType: 'campaign', entityId: target.campaignFolderId, entityStatus: 'new' };
+    }
+    if (!target.entityId) {
+      warn(
+        `candidates: skipped for campaign "${target.entityName}" — existing campaign without a DB id`,
+      );
+      return null;
+    }
+    return { entityType: 'campaign', entityId: target.entityId, entityStatus: 'existing' };
+  }
+  return null;
+}
+
+function renderFieldChangeText(fc: DistilledFieldChange): string {
+  const value = fc.proposed_value ?? '(null)';
+  return fc.reasoning ? `${fc.field} → ${value} (${fc.reasoning})` : `${fc.field} → ${value}`;
+}
+
+/**
+ * Assemble candidate insights from one target's distilled output.
+ *
+ * Deliberately total: a malformed candidate is warned about and dropped,
+ * never thrown — this runs inside synthesizeTarget's distill try-block,
+ * and a throw there would discard the entity's field changes with it.
+ * Empty provenance (A1) is warned about explicitly rather than emitted.
+ */
+export function toCandidateInsights(
+  target: CandidateTarget,
+  distillResult: CandidateDistillResult,
+  warn: (message: string) => void = () => {},
+): CandidateInsight[] {
+  const scope = resolveScope(target, warn);
+  if (!scope) return [];
+
+  const candidates: CandidateInsight[] = [];
+  const push = (raw: Omit<CandidateInsight, keyof CandidateScope | 'accountId'>): void => {
+    if (raw.sourceFileIds.length === 0) {
+      warn(
+        `candidates: dropped ${raw.origin} "${raw.text.slice(0, 60)}" — empty sourceFileIds (A1: provenance must be non-empty)`,
+      );
+      return;
+    }
+    const parsed = CandidateInsightSchema.safeParse({
+      accountId: target.accountId,
+      ...scope,
+      ...raw,
+    });
+    if (!parsed.success) {
+      warn(`candidates: dropped ${raw.origin} — ${parsed.error.issues[0]?.message ?? 'invalid'}`);
+      return;
+    }
+    candidates.push(parsed.data);
+  };
+
+  for (const fc of distillResult.field_changes) {
+    push({
+      text: renderFieldChangeText(fc),
+      sourceFileIds: fc.source_file_ids,
+      confidence: fc.confidence,
+      origin: 'field_change',
+    });
+  }
+  for (const note of distillResult.notes) {
+    push({
+      text: note.text,
+      sourceFileIds: note.source_file_ids,
+      confidence: NOTE_DEFAULT_CONFIDENCE,
+      origin: 'note',
+    });
+  }
+  return candidates;
+}

--- a/src/scan/batch-types.ts
+++ b/src/scan/batch-types.ts
@@ -7,6 +7,7 @@ import type {
 import type { CampaignObservation } from '../drive/interpret';
 import type { EntityMap } from '../drive/structure';
 import type { IdeaScanStats } from '../drive/idea-scan';
+import type { CandidateInsight } from '../drive/candidate-insight';
 
 // ── Per-batch processing ────────────────────────────────────────────────────
 
@@ -149,6 +150,13 @@ export interface EntitySynthesisResult {
   /** Sensitive companion blob, null when no sensitive content this scan. */
   synthesizedSensitiveMarkdown: string | null;
   synthesisMs: number;
+  /**
+   * D2 (#38): zod-validated candidate insights assembled from this
+   * entity's distilled output, scoped by its Target. In-memory only —
+   * persistence is D4, embedding D3. Empty for pieces (distillation
+   * skipped) and when distillation failed.
+   */
+  candidates: CandidateInsight[];
 }
 
 export interface BatchOutcome {
@@ -167,6 +175,8 @@ export interface BatchOutcome {
   campaignObsDiscarded: number;
   /** Stage 3: one entry per entity that got distill+synth. */
   synthesized: EntitySynthesisResult[];
+  /** D2 (#38): all entities' candidate insights, flattened. In-memory only. */
+  candidates: CandidateInsight[];
   /**
    * Stage-3 synthesis/apply/propose failures. Non-zero means at least
    * one entity's day did NOT land (in the DB or the review queue) —

--- a/src/scan/process-batch.ts
+++ b/src/scan/process-batch.ts
@@ -41,6 +41,7 @@ import {
   mergeIdeaCandidates,
 } from '../drive/idea-scan';
 import type { ExtractedIdea } from '../drive/idea-extraction';
+import { toCandidateInsights, type CandidateInsight } from '../drive/candidate-insight';
 import type { TraversedFile } from '../drive/types';
 import { config } from '../config';
 import { log, fmtBytes, fmtMs } from './output';
@@ -1152,6 +1153,7 @@ export async function processBatch(
       let distillResult: EntitySynthesisResult['distillResult'] = null;
       let validatedChanges: ValidatedChange[] = [];
       let distilledNotes: Array<{ text: string; source_file_ids: string[] }> = [];
+      let candidates: CandidateInsight[] = [];
       if (target.entityType === 'piece') {
         // Pieces are markdown-only: no writable fields → nothing to distill.
         // Observations flow straight into synthesis below.
@@ -1203,6 +1205,14 @@ export async function processBatch(
           ambiguousWritten: 0,
           driver: dry.driver,
         };
+
+        // D2 (#38): assemble candidate insights from the distilled output.
+        // Pure reshaping — scope comes off the Target the attributor built;
+        // no extra LLM call, nothing persisted (D4) or embedded (D3).
+        candidates = toCandidateInsights({ ...target, accountId: ctx.accountId }, dry, wlog);
+        if (candidates.length > 0) {
+          wlog(`      candidates: ${candidates.length} insight candidate(s) (in-memory — D2)`);
+        }
 
         // Validate every proposed field, drop no-ops + invalids. Same
         // gates production review uses on approve — backfill mirrors
@@ -1319,6 +1329,7 @@ export async function processBatch(
           synthesizedMarkdown: '(proposed for review — synthesis at applyDecisions)',
           synthesizedSensitiveMarkdown: null,
           synthesisMs: 0,
+          candidates,
         };
       }
 
@@ -1458,6 +1469,7 @@ export async function processBatch(
         synthesizedMarkdown,
         synthesizedSensitiveMarkdown,
         synthesisMs,
+        candidates,
       };
     };
 
@@ -1545,6 +1557,7 @@ export async function processBatch(
     accountLevelFiles,
     campaignObsDiscarded,
     synthesized,
+    candidates: synthesized.flatMap((r) => r.candidates),
     stage3Failures,
     ideaStats: ideaCtx?.stats ?? null,
   };


### PR DESCRIPTION
Closes #38.

Adapts the scan-core distillation so each scan also emits **candidate insights** —
`{accountId, entityType, entityId, entityStatus?, text, sourceFileIds, confidence, origin}` —
scoped by the existing Stage-2 attributor's Target. Pure post-processing assembly over
outputs that already exist: **no new LLM step, no classification layer, no persistence,
no embedding** (those are D4/D3). Shape matches the D1/B3 insight contract so D3
consumes it unchanged.

## What
- `src/drive/candidate-insight.ts` (new): `CandidateInsightSchema` (zod),
  `NOTE_DEFAULT_CONFIDENCE` (notes carry no confidence — neutral 0.5, not fabricated-high),
  `toCandidateInsights()`. Deliberately kept out of the mirrored `schema.ts` and the LLM
  `structured-output.ts`.
- Emit in `synthesizeTarget` right after `runDistillation`: field_change → candidate
  (rendered "field → value (reasoning)", fc's own confidence), note → candidate
  (default confidence). Carried on `EntitySynthesisResult.candidates`, aggregated
  flattened on `BatchOutcome.candidates`.
- Dryrun summary prints per-entity candidate count + samples (text, scope,
  #source files, confidence) — the acceptance surface until D4 persists.

## Scope decisions
- Scan-core path only (has the attributor); v1 forward `distillAndEmit` untouched.
- Account + campaign only — pieces keep skipping distillation (idea-extraction tier).
- New-campaign `entityId` = `campaignFolderId` (decoupled external-id ref, like the
  ideas tier) — D3/D4 resolve at reconcile/apply. **Phantom** candidates (no folder)
  are skipped with a warning: no stable ref to reconcile against.
- Provenance (A1): empty `sourceFileIds` → warn and drop, never silently emit; the
  schema also requires non-empty. Mapping is warn-and-drop throughout (never throws
  inside the distill try-block, so a bad candidate can't discard the entity's field
  changes).

## Verification
- `npx tsc --noEmit` clean; `npm test` green (37, incl. 16 new unit tests: mapping,
  all three scopes, confidence, provenance, zod rejections).
- Acceptance: dev-account dryrun (Chevy, day 2026-07-23, 3 files) printed 19
  zod-validated candidates across 1 account + 3 existing-campaign entities with
  correct scope and non-empty provenance; table row counts diffed before/after —
  zero DB writes.
