### PR TITLE
chore(deps): bump @anomaly-technology/gub-schemas to ^1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "zod": "^3.24.1"
       },
       "devDependencies": {
-        "@anomaly-technology/gub-schemas": "^0.1.0",
+        "@anomaly-technology/gub-schemas": "^1.0.0",
         "@eslint/js": "^10.0.1",
         "@types/node": "^22.10.5",
         "eslint": "^10.8.1",
@@ -34,9 +34,9 @@
       }
     },
     "node_modules/@anomaly-technology/gub-schemas": {
-      "version": "0.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@anomaly-technology/gub-schemas/0.1.0/2c22821d70e35f1c9bcb67246332d6f698ea3765",
-      "integrity": "sha512-wbjJ4/yKCF+aaPJfoTR290nTq2I0rHqL+IyeZYr0GaSluMM2e7ifY48tfGBT8Qi8Db9r9QodsSFR0Qne68m/ag==",
+      "version": "1.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@anomaly-technology/gub-schemas/1.0.0/d098d424171e47deeb6f74098c7de0a21a2d7edb",
+      "integrity": "sha512-eSF34PBYdIx8uh0d1ZrV0GyPP0jjY86j9lw1452PUV9ttwiovlQ9x89vKoJNpzfTka31z3Z4fR25MCvuyQjofg==",
       "dev": true,
       "license": "UNLICENSED",
       "bin": {
@@ -4889,9 +4889,9 @@
   },
   "dependencies": {
     "@anomaly-technology/gub-schemas": {
-      "version": "0.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@anomaly-technology/gub-schemas/0.1.0/2c22821d70e35f1c9bcb67246332d6f698ea3765",
-      "integrity": "sha512-wbjJ4/yKCF+aaPJfoTR290nTq2I0rHqL+IyeZYr0GaSluMM2e7ifY48tfGBT8Qi8Db9r9QodsSFR0Qne68m/ag==",
+      "version": "1.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@anomaly-technology/gub-schemas/1.0.0/d098d424171e47deeb6f74098c7de0a21a2d7edb",
+      "integrity": "sha512-eSF34PBYdIx8uh0d1ZrV0GyPP0jjY86j9lw1452PUV9ttwiovlQ9x89vKoJNpzfTka31z3Z4fR25MCvuyQjofg==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
-    "@anomaly-technology/gub-schemas": "^0.1.0",
+    "@anomaly-technology/gub-schemas": "^1.0.0",
     "@eslint/js": "^10.0.1",
     "@types/node": "^22.10.5",
     "eslint": "^10.8.1",


### PR DESCRIPTION
1.0.0 restores drive_edit_stats run-framing (sync_run_id + PK) that the code (src/forward/stats.ts) requires; ^0.1.0/^0.2.0 lacked it, breaking prisma generate + tsc after the package adoption (#4). Lock regenerated via --package-lock-only (node_modules is a root-owned Docker artifact locally; CI builds it fresh).