### PR TITLE
feat(drive): scoped retrieval + reconciliation ops over candidate insights (D3 #39)

### DIFF
--- a/src/ai/embed.ts
+++ b/src/ai/embed.ts
@@ -1,0 +1,190 @@
+/**
+ * embed.ts — Gemini-backed text embedding with mock fallback (D3 #39).
+ *
+ * Mirrors the gemini.client.ts driver pattern:
+ *   - GEMINI_USE_ENTERPRISE+GCP_PROJECT_ID → enterprise surface via ADC
+ *   - GEMINI_API_KEY                        → consumer Developer API
+ *   - neither                               → deterministic mock embedder so
+ *                                             dev/dryrun keeps running keyless.
+ *
+ * Embedding stack per ruling B4 (recorded in gub-schemas
+ * prisma/schema.prisma:580-586): gemini-embedding-001 at 1536 dims via MRL
+ * truncation. Non-native dims (≠3072) come back UN-normalized, so every
+ * vector is L2-normalized here before it's compared or stored — skipping
+ * that skews pgvector `<=>` cosine distances.
+ *
+ * taskType is SEMANTIC_SIMILARITY (symmetric dedup): candidates and stored
+ * insights are the same kind of text, not a query/document pair.
+ */
+
+import { GoogleGenAI } from '@google/genai';
+import { config } from '../config';
+import { logger } from '../logger';
+import { isRetryable } from './gemini.client';
+
+export const EMBEDDING_MODEL = 'gemini-embedding-001';
+export const EMBEDDING_DIM = 1536;
+
+/**
+ * The Developer API caps embedContent batches at 100 texts per request;
+ * chunking below the cap keeps one request comfortably sized either way.
+ */
+const EMBED_BATCH_SIZE = 100;
+
+const MAX_ATTEMPTS = 3;
+const BASE_BACKOFF_MS = 1000; // 1s → 3s → 9s, same posture as completions
+
+export interface EmbeddingDriver {
+  readonly name: string;
+  /** Embed a list of texts; result[i] corresponds to texts[i]. */
+  embedTexts(texts: string[]): Promise<number[][]>;
+}
+
+function l2Normalize(vec: number[]): number[] {
+  let sumSq = 0;
+  for (const x of vec) sumSq += x * x;
+  const norm = Math.sqrt(sumSq);
+  // Degenerate (all-zero) vectors can't be normalized — pass through
+  // rather than divide by zero; cosine against them is meaningless anyway.
+  if (!Number.isFinite(norm) || norm === 0) return vec;
+  return vec.map((x) => x / norm);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+class GeminiEmbeddingDriver implements EmbeddingDriver {
+  readonly name: string;
+  private client: GoogleGenAI;
+
+  constructor(init: { project: string; location: string } | { apiKey: string }) {
+    // Same construction as GeminiLlmDriver: our loop owns retries, so the
+    // SDK's built-in retry is pinned off to keep backoff deterministic.
+    const httpOptions = { retryOptions: { attempts: 1 } };
+    if ('project' in init) {
+      this.name = 'gemini-enterprise';
+      this.client = new GoogleGenAI({
+        enterprise: true,
+        project: init.project,
+        location: init.location,
+        httpOptions,
+      });
+    } else {
+      this.name = 'gemini';
+      this.client = new GoogleGenAI({ apiKey: init.apiKey, httpOptions });
+    }
+  }
+
+  async embedTexts(texts: string[]): Promise<number[][]> {
+    const out: number[][] = [];
+    for (let i = 0; i < texts.length; i += EMBED_BATCH_SIZE) {
+      const chunk = texts.slice(i, i + EMBED_BATCH_SIZE);
+      const embeddings = await this.embedChunk(chunk);
+      out.push(...embeddings);
+    }
+    return out;
+  }
+
+  private async embedChunk(chunk: string[]): Promise<number[][]> {
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      try {
+        const res = await this.client.models.embedContent({
+          model: EMBEDDING_MODEL,
+          contents: chunk,
+          config: {
+            outputDimensionality: EMBEDDING_DIM,
+            taskType: 'SEMANTIC_SIMILARITY',
+          },
+        });
+        const embeddings = res.embeddings ?? [];
+        if (embeddings.length !== chunk.length) {
+          throw new Error(
+            `[embed] expected ${chunk.length} embeddings, got ${embeddings.length}`,
+          );
+        }
+        return embeddings.map((e, idx) => {
+          const values = e.values;
+          if (!values || values.length !== EMBEDDING_DIM) {
+            throw new Error(
+              `[embed] embedding ${idx} has ${values?.length ?? 0} dims, expected ${EMBEDDING_DIM}`,
+            );
+          }
+          return l2Normalize(values);
+        });
+      } catch (err) {
+        lastErr = err;
+        // Our own shape errors above never match isRetryable's patterns —
+        // only transport and API-level transient failures retry.
+        const retryable = isRetryable(err);
+        const willRetry = retryable && attempt < MAX_ATTEMPTS;
+        logger.debug(
+          { err, model: EMBEDDING_MODEL, batch: chunk.length, attempt, retryable, willRetry },
+          '[embed] embedContent failed',
+        );
+        if (!willRetry) break;
+        await sleep(BASE_BACKOFF_MS * Math.pow(3, attempt - 1));
+      }
+    }
+    throw lastErr;
+  }
+}
+
+/**
+ * Keyless fallback: a deterministic pseudo-embedding derived from an FNV-1a
+ * hash of the text, so dev/dryrun and hermetic-ish local runs behave
+ * consistently (same text → same vector) without a Gemini credential.
+ * Same philosophy as MockLlmDriver — keep the pipeline running, loudly.
+ */
+class MockEmbeddingDriver implements EmbeddingDriver {
+  readonly name = 'mock';
+
+  async embedTexts(texts: string[]): Promise<number[][]> {
+    logger.info({ count: texts.length }, '[embed:mock] returning deterministic pseudo-vectors');
+    return texts.map((t) => l2Normalize(pseudoVector(t)));
+  }
+}
+
+function pseudoVector(text: string): number[] {
+  // FNV-1a seed, then a mulberry32 stream — cheap, stable across runs.
+  let seed = 0x811c9dc5;
+  for (let i = 0; i < text.length; i++) {
+    seed ^= text.charCodeAt(i);
+    seed = Math.imul(seed, 0x01000193);
+  }
+  let state = seed >>> 0;
+  const next = (): number => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+  const vec = new Array<number>(EMBEDDING_DIM);
+  for (let i = 0; i < EMBEDDING_DIM; i++) vec[i] = next() * 2 - 1;
+  return vec;
+}
+
+function createEmbeddingDriver(): EmbeddingDriver {
+  if (config.GEMINI_USE_ENTERPRISE && config.GCP_PROJECT_ID) {
+    return new GeminiEmbeddingDriver({
+      project: config.GCP_PROJECT_ID,
+      location: config.GEMINI_LOCATION,
+    });
+  }
+  if (config.GEMINI_API_KEY) {
+    return new GeminiEmbeddingDriver({ apiKey: config.GEMINI_API_KEY });
+  }
+  logger.warn(
+    '[embed] no Gemini config (GEMINI_USE_ENTERPRISE+GCP_PROJECT_ID or GEMINI_API_KEY) — using mock embedder. Vectors are deterministic pseudo-embeddings.',
+  );
+  return new MockEmbeddingDriver();
+}
+
+export const defaultEmbedder: EmbeddingDriver = createEmbeddingDriver();
+
+/** Convenience wrapper over the module-level driver. */
+export function embedTexts(texts: string[]): Promise<number[][]> {
+  return defaultEmbedder.embedTexts(texts);
+}

--- a/src/ai/gemini.client.ts
+++ b/src/ai/gemini.client.ts
@@ -48,7 +48,7 @@ import type {
 const MAX_ATTEMPTS = 3;
 const BASE_BACKOFF_MS = 1000; // 1s → 3s → 9s (3^attempt)
 
-function isRetryable(err: unknown): boolean {
+export function isRetryable(err: unknown): boolean {
   if (!err) return false;
   // API-level errors carry a typed HTTP status (SDK-recommended handling):
   // retry rate limits + server-side failures, never other 4xx.

--- a/src/ai/index.ts
+++ b/src/ai/index.ts
@@ -1,5 +1,7 @@
 export { runPreset, parseLlmJson } from './prompt-preset.service';
 export { defaultLlm } from './gemini.client';
+export { embedTexts, defaultEmbedder, EMBEDDING_MODEL, EMBEDDING_DIM } from './embed';
+export type { EmbeddingDriver } from './embed';
 export type { LlmDriver, LlmCompletionRequest, LlmCompletionResult, LlmUsage } from './ai.types';
 // The SDK's schema surface, re-exported so consumers never import the vendor
 // package directly (one place to swap on the next SDK migration). SchemaType

--- a/src/backfill/run.ts
+++ b/src/backfill/run.ts
@@ -2,6 +2,8 @@
 // former scripts/backfill.ts monolith — behavior-preserving reorganization.
 import { writeFileSync } from 'node:fs';
 import { prisma } from '../prisma';
+import { config } from '../config';
+import { reconcileCandidates } from '../drive/insight-reconcile';
 import type { Attributor } from '../drive/structure';
 import type { TraversedFile } from '../drive/types';
 import { parseArgs, DEFAULT_CONCURRENCY, type Args, type BackfillRunResult } from './args';
@@ -341,6 +343,53 @@ async function runBackfillInner(args: Args): Promise<BackfillRunResult> {
           log(`     │ ${line}`);
         }
         log('     └─────────────────────────────────────');
+      }
+    }
+
+    // D3 (#39): flag-gated reconciliation over the scan's aggregated
+    // candidates. Op producer only — zero DB writes in any mode. Fails
+    // soft (a missing preset on an unseeded dev DB must not kill the
+    // scan print).
+    if (config.INSIGHT_RECONCILE === 'dryrun' && outcome.candidates.length > 0) {
+      log('');
+      log(
+        `  ── Reconciliation ops (${outcome.candidates.length} candidate(s) — D3 dryrun, not persisted) ──`,
+      );
+      try {
+        const reconcileStart = Date.now();
+        const ops = await reconcileCandidates(outcome.candidates, {
+          warn: (m) => log(`     ⚠ ${m}`),
+        });
+        for (const op of ops) {
+          const c = op.candidate;
+          const text = c.text.length > 100 ? `${c.text.slice(0, 100)}…` : c.text;
+          const scope =
+            c.entityType === 'account'
+              ? `account ${c.entityId}`
+              : `campaign(${c.entityStatus ?? 'existing'}) ${c.entityId}`;
+          const targetIdx = op.targetInsightId
+            ? op.retrieval.neighborIds.indexOf(op.targetInsightId)
+            : -1;
+          const distance = targetIdx >= 0 ? op.retrieval.distances[targetIdx] : undefined;
+          const parts = [
+            `confidence ${op.confidence.toFixed(2)}`,
+            `retrieved ${op.retrieval.neighborIds.length}/${op.retrieval.k}`,
+          ];
+          if (op.targetInsightId) {
+            parts.unshift(
+              `target ${op.targetInsightId}${distance !== undefined ? ` (d=${distance.toFixed(3)})` : ''}`,
+            );
+          }
+          if (op.demotedFrom) parts.push(`demoted from ${op.demotedFrom}`);
+          if (op.unresolvedEntity) parts.push('unresolved entity');
+          log(`     · ${op.op}  "${text}"`);
+          log(`         ${scope}  ·  ${parts.join('  ·  ')}`);
+        }
+        log(`     ✓ ${ops.length} op(s) in ${fmtMs(Date.now() - reconcileStart)}`);
+      } catch (err) {
+        log(
+          `     ⚠ reconcile skipped: ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -64,6 +64,13 @@ const EnvSchema = z.object({
    * synth → ~5min parallel.
    */
   SYNTH_CONCURRENCY: z.string().default('8').transform(Number),
+  /**
+   * D3 (#39): reconcile the scan's candidate insights against the insight
+   * store. 'off' (default) skips reconciliation entirely; 'dryrun' embeds,
+   * retrieves top-K neighbors, and prints zod-validated ops after the D2
+   * candidate print — zero DB writes in any mode (persistence is D4).
+   */
+  INSIGHT_RECONCILE: z.enum(['off', 'dryrun']).default('off'),
 
   // ── Notify URLs ──────────────────────────────────────────────────────────
   GUB_ADMIN_BASE_URL: z.string().url().default('http://localhost:5173'),

--- a/src/drive/__tests__/insight-reconcile.test.ts
+++ b/src/drive/__tests__/insight-reconcile.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Hermetic suite for insight-reconcile.ts (D3 #39).
+ *
+ * Everything external is injected through ReconcileOptions (embed,
+ * retrieve, runPresetFn) — no prisma, no Gemini. The module boundary
+ * mocks below only neutralize import-time side effects (config env
+ * validation, prisma client construction).
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../config', () => ({ config: {} }));
+vi.mock('../../logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock('../../prisma', () => ({ prisma: {} }));
+
+import type { runPreset } from '../../ai';
+import type { CandidateInsight } from '../candidate-insight';
+import {
+  InsightOpSchema,
+  RECONCILE_CONFIDENCE_FLOOR,
+  reconcileCandidate,
+  reconcileCandidates,
+  type InsightNeighbor,
+} from '../insight-reconcile';
+
+const ACCOUNT_ID = 'aaaaaaaa-0000-4000-8000-000000000001';
+const CAMPAIGN_ID = 'bbbbbbbb-0000-4000-8000-000000000002';
+const NEIGHBOR_1 = '11111111-1111-4111-8111-111111111111';
+const NEIGHBOR_2 = '22222222-2222-4222-8222-222222222222';
+const UNKNOWN_ID = '99999999-9999-4999-8999-999999999999';
+
+const NEIGHBOR_1_UPDATED_AT = new Date('2026-08-01T12:00:00.000Z');
+
+function candidate(over: Partial<CandidateInsight> = {}): CandidateInsight {
+  return {
+    accountId: ACCOUNT_ID,
+    entityType: 'campaign',
+    entityId: CAMPAIGN_ID,
+    entityStatus: 'existing',
+    text: 'Launch date shifted from May to June 1.',
+    sourceFileIds: ['file_a'],
+    confidence: 0.8,
+    origin: 'note',
+    ...over,
+  };
+}
+
+function neighbor(id: string, over: Partial<InsightNeighbor> = {}): InsightNeighbor {
+  return {
+    id,
+    text: 'Launch is planned for May.',
+    state: 'active',
+    updatedAt: NEIGHBOR_1_UPDATED_AT,
+    distance: 0.12,
+    ...over,
+  };
+}
+
+type LlmResponse = {
+  op: string;
+  target_id?: string | null;
+  new_text?: string | null;
+  reasoning?: string;
+  confidence?: number;
+};
+
+function presetReturning(response: LlmResponse): typeof runPreset {
+  return vi.fn(async () => ({
+    text: JSON.stringify({ reasoning: 'because', confidence: 0.9, ...response }),
+    driver: 'test',
+    model: 'test-model',
+    prompt: 'rendered',
+  })) as unknown as typeof runPreset;
+}
+
+const NEIGHBORS = [neighbor(NEIGHBOR_1), neighbor(NEIGHBOR_2, { distance: 0.4 })];
+
+describe('reconcileCandidate — verb mapping', () => {
+  it('maps ADD with no target and full retrieval telemetry', async () => {
+    const op = await reconcileCandidate(candidate(), NEIGHBORS, {
+      runPresetFn: presetReturning({ op: 'ADD' }),
+    });
+    expect(op.op).toBe('ADD');
+    expect(op.targetInsightId).toBeUndefined();
+    expect(op.targetUpdatedAt).toBeUndefined();
+    expect(op.retrieval.neighborIds).toEqual([NEIGHBOR_1, NEIGHBOR_2]);
+    expect(op.retrieval.distances).toEqual([0.12, 0.4]);
+  });
+
+  it('maps UPDATE with target, stale snapshot, and merged text', async () => {
+    const op = await reconcileCandidate(candidate(), NEIGHBORS, {
+      runPresetFn: presetReturning({ op: 'UPDATE', target_id: NEIGHBOR_1, new_text: 'merged text' }),
+    });
+    expect(op.op).toBe('UPDATE');
+    expect(op.targetInsightId).toBe(NEIGHBOR_1);
+    expect(op.targetUpdatedAt).toBe(NEIGHBOR_1_UPDATED_AT.toISOString());
+    expect(op.newText).toBe('merged text');
+  });
+
+  it('falls back to the candidate text when UPDATE omits new_text', async () => {
+    const op = await reconcileCandidate(candidate(), NEIGHBORS, {
+      runPresetFn: presetReturning({ op: 'UPDATE', target_id: NEIGHBOR_1, new_text: null }),
+    });
+    expect(op.newText).toBe(candidate().text);
+  });
+
+  it('maps SUPERSEDE with target and no newText', async () => {
+    const op = await reconcileCandidate(candidate(), NEIGHBORS, {
+      runPresetFn: presetReturning({ op: 'SUPERSEDE', target_id: NEIGHBOR_2 }),
+    });
+    expect(op.op).toBe('SUPERSEDE');
+    expect(op.targetInsightId).toBe(NEIGHBOR_2);
+    expect(op.newText).toBeUndefined();
+  });
+
+  it('maps NOOP with target', async () => {
+    const op = await reconcileCandidate(candidate(), NEIGHBORS, {
+      runPresetFn: presetReturning({ op: 'NOOP', target_id: NEIGHBOR_1 }),
+    });
+    expect(op.op).toBe('NOOP');
+    expect(op.targetInsightId).toBe(NEIGHBOR_1);
+  });
+
+  it('passes entity_type, candidate_text, and neighbors to the preset', async () => {
+    const runPresetFn = presetReturning({ op: 'ADD' });
+    await reconcileCandidate(candidate(), NEIGHBORS, { runPresetFn });
+    const call = (runPresetFn as unknown as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(call.key).toBe('drive.insight_reconcile.v1');
+    expect(call.variables.entity_type).toBe('campaign');
+    expect(call.variables.candidate_text).toBe(candidate().text);
+    expect(call.variables.neighbors_json).toContain(NEIGHBOR_1);
+    expect(call.variables.neighbors_json).toContain('Launch is planned for May.');
+  });
+
+  it('rejects a malformed LLM op value', async () => {
+    await expect(
+      reconcileCandidate(candidate(), NEIGHBORS, {
+        runPresetFn: presetReturning({ op: 'MERGE', target_id: NEIGHBOR_1 }),
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('reconcileCandidate — guards', () => {
+  it('demotes a merge verb below the confidence floor to ADD', async () => {
+    const warn = vi.fn();
+    const op = await reconcileCandidate(candidate(), NEIGHBORS, {
+      runPresetFn: presetReturning({
+        op: 'NOOP',
+        target_id: NEIGHBOR_1,
+        confidence: RECONCILE_CONFIDENCE_FLOOR - 0.1,
+      }),
+      warn,
+    });
+    expect(op.op).toBe('ADD');
+    expect(op.demotedFrom).toBe('NOOP');
+    expect(op.targetInsightId).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('below floor'));
+  });
+
+  it('keeps a merge verb at exactly the floor', async () => {
+    const op = await reconcileCandidate(candidate(), NEIGHBORS, {
+      runPresetFn: presetReturning({
+        op: 'NOOP',
+        target_id: NEIGHBOR_1,
+        confidence: RECONCILE_CONFIDENCE_FLOOR,
+      }),
+    });
+    expect(op.op).toBe('NOOP');
+  });
+
+  it('demotes a hallucinated target (id not among retrieved neighbors) to ADD', async () => {
+    const warn = vi.fn();
+    const op = await reconcileCandidate(candidate(), NEIGHBORS, {
+      runPresetFn: presetReturning({ op: 'UPDATE', target_id: UNKNOWN_ID, new_text: 'x' }),
+      warn,
+    });
+    expect(op.op).toBe('ADD');
+    expect(op.demotedFrom).toBe('UPDATE');
+    expect(op.targetInsightId).toBeUndefined();
+    expect(op.newText).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('not among retrieved neighbors'));
+  });
+
+  it('demotes a merge verb with a missing target_id to ADD', async () => {
+    const op = await reconcileCandidate(candidate(), NEIGHBORS, {
+      runPresetFn: presetReturning({ op: 'SUPERSEDE', target_id: null }),
+    });
+    expect(op.op).toBe('ADD');
+    expect(op.demotedFrom).toBe('SUPERSEDE');
+  });
+});
+
+describe('reconcileCandidates — orchestration', () => {
+  it("bypasses retrieval for 'new'-campaign candidates (folder-ref entityId)", async () => {
+    const embed = vi.fn();
+    const retrieve = vi.fn();
+    const runPresetFn = presetReturning({ op: 'ADD' });
+    const [op] = await reconcileCandidates(
+      [candidate({ entityStatus: 'new', entityId: 'folder_abc123' })],
+      { embed, retrieve, runPresetFn },
+    );
+    expect(op!.op).toBe('ADD');
+    expect(op!.unresolvedEntity).toBe(true);
+    expect(op!.retrieval).toEqual({ k: 3, neighborIds: [], distances: [] });
+    expect(embed).not.toHaveBeenCalled();
+    expect(retrieve).not.toHaveBeenCalled();
+    expect(runPresetFn).not.toHaveBeenCalled();
+  });
+
+  it('emits ADD without an LLM call on an empty container', async () => {
+    const embed = vi.fn(async (texts: string[]) => texts.map(() => [1, 0, 0]));
+    const retrieve = vi.fn(async () => []);
+    const runPresetFn = presetReturning({ op: 'NOOP', target_id: NEIGHBOR_1 });
+    const [op] = await reconcileCandidates([candidate()], { embed, retrieve, runPresetFn });
+    expect(op!.op).toBe('ADD');
+    expect(op!.reasoning).toContain('empty container');
+    expect(op!.unresolvedEntity).toBeUndefined();
+    expect(runPresetFn).not.toHaveBeenCalled();
+  });
+
+  it('warns and emits unresolved ADD for a non-uuid entityId on an existing entity', async () => {
+    const warn = vi.fn();
+    const embed = vi.fn();
+    const [op] = await reconcileCandidates([candidate({ entityId: 'not-a-uuid' })], {
+      embed,
+      warn,
+    });
+    expect(op!.op).toBe('ADD');
+    expect(op!.unresolvedEntity).toBe(true);
+    expect(embed).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('non-uuid entityId'));
+  });
+
+  it('embeds all retrievable candidates in one batch and preserves input order', async () => {
+    const embed = vi.fn(async (texts: string[]) => texts.map((_, i) => [i, 0, 0]));
+    const seen: Array<{ entityId: string; vec: number[] }> = [];
+    const retrieve = vi.fn(
+      async (scope: { entityType: string; entityId: string }, vec: number[]) => {
+        seen.push({ entityId: scope.entityId, vec });
+        return [neighbor(NEIGHBOR_1)];
+      },
+    );
+    const runPresetFn = presetReturning({ op: 'NOOP', target_id: NEIGHBOR_1 });
+    const ops = await reconcileCandidates(
+      [
+        candidate({ text: 'first', entityType: 'account', entityId: ACCOUNT_ID }),
+        candidate({ entityStatus: 'new', entityId: 'folder_x', text: 'second' }),
+        candidate({ text: 'third' }),
+      ],
+      { embed, retrieve, runPresetFn },
+    );
+    expect(embed).toHaveBeenCalledTimes(1);
+    expect(embed).toHaveBeenCalledWith(['first', 'third']);
+    expect(seen).toEqual([
+      { entityId: ACCOUNT_ID, vec: [0, 0, 0] },
+      { entityId: CAMPAIGN_ID, vec: [1, 0, 0] },
+    ]);
+    expect(ops.map((o) => o.candidate.text)).toEqual(['first', 'second', 'third']);
+    expect(ops[1]!.unresolvedEntity).toBe(true);
+    expect(ops[0]!.op).toBe('NOOP');
+    expect(ops[2]!.op).toBe('NOOP');
+  });
+
+  it('passes the configured k through to retrieval and telemetry', async () => {
+    const embed = vi.fn(async (texts: string[]) => texts.map(() => [1]));
+    const retrieve = vi.fn(async () => [neighbor(NEIGHBOR_1)]);
+    const runPresetFn = presetReturning({ op: 'NOOP', target_id: NEIGHBOR_1 });
+    const [op] = await reconcileCandidates([candidate()], {
+      k: 5,
+      embed,
+      retrieve,
+      runPresetFn,
+    });
+    expect(retrieve).toHaveBeenCalledWith(expect.anything(), [1], 5);
+    expect(op!.retrieval.k).toBe(5);
+  });
+});
+
+describe('InsightOpSchema — zod rejections', () => {
+  const base = {
+    candidate: candidate(),
+    reasoning: 'because',
+    confidence: 0.9,
+    retrieval: { k: 3, neighborIds: [NEIGHBOR_1], distances: [0.1] },
+  };
+
+  it('rejects UPDATE without a target', () => {
+    const res = InsightOpSchema.safeParse({ ...base, op: 'UPDATE', newText: 'x' });
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects a merge verb without targetUpdatedAt', () => {
+    const res = InsightOpSchema.safeParse({
+      ...base,
+      op: 'NOOP',
+      targetInsightId: NEIGHBOR_1,
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects ADD carrying a target', () => {
+    const res = InsightOpSchema.safeParse({
+      ...base,
+      op: 'ADD',
+      targetInsightId: NEIGHBOR_1,
+      targetUpdatedAt: NEIGHBOR_1_UPDATED_AT.toISOString(),
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects confidence out of range', () => {
+    const res = InsightOpSchema.safeParse({ ...base, op: 'ADD', confidence: 1.5 });
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects a non-uuid targetInsightId', () => {
+    const res = InsightOpSchema.safeParse({
+      ...base,
+      op: 'NOOP',
+      targetInsightId: 'nope',
+      targetUpdatedAt: NEIGHBOR_1_UPDATED_AT.toISOString(),
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it('accepts a fully-formed UPDATE', () => {
+    const res = InsightOpSchema.safeParse({
+      ...base,
+      op: 'UPDATE',
+      targetInsightId: NEIGHBOR_1,
+      targetUpdatedAt: NEIGHBOR_1_UPDATED_AT.toISOString(),
+      newText: 'merged',
+    });
+    expect(res.success).toBe(true);
+  });
+});

--- a/src/drive/insight-reconcile.ts
+++ b/src/drive/insight-reconcile.ts
@@ -1,0 +1,372 @@
+/**
+ * insight-reconcile.ts — D3 (#39): scoped retrieval + reconciliation op.
+ *
+ * Takes D2's in-memory CandidateInsight[], embeds each candidate, retrieves
+ * its top-K ACTIVE stored insights within (entity_type, entity_id) via raw
+ * pgvector `<=>`, runs the drive.insight_reconcile.v1 preset, and emits
+ * zod-validated InsightOp[] — ADD | UPDATE(target) | SUPERSEDE(target) |
+ * NOOP(target). Op PRODUCER only: no writes to insights/insight_changes
+ * (that's D4), no idempotency keys, no review gate (B1/D4).
+ *
+ * Store access is prisma.$queryRaw on purpose: drive-sync's prisma schema
+ * has no Insight models (schema-package adoption is PR #4, out of scope),
+ * and the `embedding` column is Unsupported("vector") anyway. The table
+ * shape is frozen in gub-schemas feat/schema-v0.3.0-insights; dev DBs get
+ * the spec's Appendix A DDL until the canonical D1 (#37) migration lands.
+ *
+ * Kept out of structured-output.ts (existing prompts' schemas) and
+ * schema.ts (GUB-lockstep) per the D2 precedent — the Gemini response
+ * schema and the op contract live here, with their consumer.
+ */
+
+import { z } from 'zod';
+import { prisma } from '../prisma';
+import { logger } from '../logger';
+import {
+  embedTexts,
+  parseLlmJson,
+  runPreset,
+  SchemaType,
+  type Schema,
+} from '../ai';
+import { CandidateInsightSchema, type CandidateInsight } from './candidate-insight';
+
+export const RECONCILE_PRESET_KEY = 'drive.insight_reconcile.v1';
+
+/** Top-K neighbors per candidate. Brute-force `<=>` per B4 — container
+ * sizes are tens–hundreds; no vector index tuning in D3. */
+export const DEFAULT_RETRIEVAL_K = 3;
+
+/**
+ * Confidence floor (pending ratification): a merge verb the reconciler
+ * itself isn't sure about demotes to ADD — a duplicate is recoverable,
+ * a wrong merge is not.
+ */
+export const RECONCILE_CONFIDENCE_FLOOR = 0.6;
+
+const MERGE_OPS = ['UPDATE', 'SUPERSEDE', 'NOOP'] as const;
+
+/**
+ * The D3→D4 op contract. `targetInsightId` + `targetUpdatedAt` are the
+ * stale-race snapshot: D4's transactional apply re-reads the target and
+ * bails when updated_at moved. `retrieval` is telemetry for D4 debugging
+ * and the eval — never prompt input.
+ */
+export const InsightOpSchema = z
+  .object({
+    op: z.enum(['ADD', 'UPDATE', 'SUPERSEDE', 'NOOP']),
+    candidate: CandidateInsightSchema,
+    targetInsightId: z.string().uuid().optional(),
+    targetUpdatedAt: z.string().datetime({ offset: true }).optional(),
+    /** UPDATE only: merged/refreshed insight text. */
+    newText: z.string().min(1).optional(),
+    reasoning: z.string(),
+    confidence: z.number().min(0).max(1),
+    /** 'new'-campaign candidates: entityId is a folder ref, not a store uuid. */
+    unresolvedEntity: z.literal(true).optional(),
+    /** Set when a guard downgraded a merge verb (floor / hallucinated target). */
+    demotedFrom: z.enum(MERGE_OPS).optional(),
+    retrieval: z.object({
+      k: z.number().int().nonnegative(),
+      neighborIds: z.array(z.string().uuid()),
+      distances: z.array(z.number()),
+    }),
+  })
+  .superRefine((op, ctx) => {
+    if (op.op === 'ADD') {
+      if (op.targetInsightId !== undefined) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'ADD must not carry a target' });
+      }
+      return;
+    }
+    if (op.targetInsightId === undefined) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: `${op.op} requires targetInsightId` });
+    }
+    if (op.targetUpdatedAt === undefined) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: `${op.op} requires targetUpdatedAt` });
+    }
+  });
+
+export type InsightOp = z.infer<typeof InsightOpSchema>;
+
+// ── LLM response contract (this prompt's schema lives HERE, not in
+// structured-output.ts — D2 precedent) ───────────────────────────────────────
+
+const reconcileResponseSchema: Schema = {
+  type: SchemaType.OBJECT,
+  properties: {
+    op: {
+      type: SchemaType.STRING,
+      enum: ['ADD', 'UPDATE', 'SUPERSEDE', 'NOOP'],
+      description: 'The single reconciliation operation for the candidate.',
+    },
+    target_id: {
+      type: SchemaType.STRING,
+      nullable: true,
+      description:
+        'For UPDATE/SUPERSEDE/NOOP: the id of the neighbor insight this operation targets. MUST be one of the neighbor ids shown in the prompt. NULL for ADD.',
+    },
+    new_text: {
+      type: SchemaType.STRING,
+      nullable: true,
+      description:
+        'For UPDATE: the merged/refreshed insight text (no facts lost). NULL otherwise.',
+    },
+    reasoning: {
+      type: SchemaType.STRING,
+      description: 'One or two sentences justifying the operation.',
+    },
+    confidence: {
+      type: SchemaType.NUMBER,
+      description: '0.0–1.0 — confidence in the chosen operation.',
+    },
+  },
+  required: ['op', 'reasoning', 'confidence'],
+};
+
+const ReconcileLlmResponseSchema = z.object({
+  op: z.enum(['ADD', 'UPDATE', 'SUPERSEDE', 'NOOP']),
+  target_id: z.string().nullish(),
+  new_text: z.string().nullish(),
+  reasoning: z.string(),
+  confidence: z.number().min(0).max(1),
+});
+
+// ── Retrieval ────────────────────────────────────────────────────────────────
+
+export interface RetrievalScope {
+  entityType: 'account' | 'campaign';
+  entityId: string;
+}
+
+export interface InsightNeighbor {
+  id: string;
+  text: string;
+  state: string;
+  updatedAt: Date;
+  /** Cosine distance (`<=>`) from the candidate embedding. */
+  distance: number;
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Top-K ACTIVE insights in the candidate's container by cosine distance.
+ * Raw SQL (see module header); explicit `::vector` / `::uuid` casts, the
+ * vector passed as a `[x,y,…]` string literal.
+ */
+export async function retrieveNeighbors(
+  scope: RetrievalScope,
+  queryVec: number[],
+  k: number = DEFAULT_RETRIEVAL_K,
+): Promise<InsightNeighbor[]> {
+  const vec = `[${queryVec.join(',')}]`;
+  const rows = await prisma.$queryRaw<
+    Array<{ id: string; text: string; state: string; updated_at: Date; distance: number }>
+  >`
+    SELECT id::text AS id, text, state, updated_at,
+           embedding <=> ${vec}::vector AS distance
+    FROM insights
+    WHERE entity_type = ${scope.entityType}
+      AND entity_id = ${scope.entityId}::uuid
+      AND state = 'active'
+      AND embedding IS NOT NULL
+    ORDER BY embedding <=> ${vec}::vector
+    LIMIT ${k}
+  `;
+  return rows.map((r) => ({
+    id: r.id,
+    text: r.text,
+    state: r.state,
+    updatedAt: r.updated_at,
+    distance: r.distance,
+  }));
+}
+
+// ── Reconciliation ───────────────────────────────────────────────────────────
+
+/** Injectable seams so the hermetic suite never touches prisma/Gemini. */
+export interface ReconcileOptions {
+  k?: number;
+  confidenceFloor?: number;
+  embed?: (texts: string[]) => Promise<number[][]>;
+  retrieve?: typeof retrieveNeighbors;
+  runPresetFn?: typeof runPreset;
+  warn?: (message: string) => void;
+}
+
+function baseRetrieval(k: number, neighbors: InsightNeighbor[]): InsightOp['retrieval'] {
+  return {
+    k,
+    neighborIds: neighbors.map((n) => n.id),
+    distances: neighbors.map((n) => n.distance),
+  };
+}
+
+function addOp(
+  candidate: CandidateInsight,
+  reasoning: string,
+  confidence: number,
+  retrieval: InsightOp['retrieval'],
+  extras: Partial<Pick<InsightOp, 'unresolvedEntity' | 'demotedFrom'>> = {},
+): InsightOp {
+  return InsightOpSchema.parse({
+    op: 'ADD',
+    candidate,
+    reasoning,
+    confidence,
+    retrieval,
+    ...extras,
+  });
+}
+
+/**
+ * One candidate vs its retrieved neighbors → one validated op.
+ * Caller guarantees `neighbors` is non-empty (the empty-container ADD
+ * short-circuit lives in reconcileCandidates).
+ */
+export async function reconcileCandidate(
+  candidate: CandidateInsight,
+  neighbors: InsightNeighbor[],
+  opts: ReconcileOptions = {},
+): Promise<InsightOp> {
+  const runPresetFn = opts.runPresetFn ?? runPreset;
+  const floor = opts.confidenceFloor ?? RECONCILE_CONFIDENCE_FLOOR;
+  const warn = opts.warn ?? ((m: string): void => logger.warn(`[insight-reconcile] ${m}`));
+  const retrieval = baseRetrieval(opts.k ?? neighbors.length, neighbors);
+
+  const completion = await runPresetFn({
+    key: RECONCILE_PRESET_KEY,
+    responseSchema: reconcileResponseSchema,
+    variables: {
+      entity_type: candidate.entityType,
+      candidate_text: candidate.text,
+      neighbors_json: JSON.stringify(
+        neighbors.map((n) => ({ id: n.id, text: n.text })),
+        null,
+        2,
+      ),
+    },
+  });
+
+  const response = ReconcileLlmResponseSchema.parse(parseLlmJson(completion.text));
+
+  if (response.op === 'ADD') {
+    return addOp(candidate, response.reasoning, response.confidence, retrieval);
+  }
+
+  // Hallucinated-target guard: an op referencing an id the LLM wasn't
+  // shown is invalid — a duplicate ADD is the safe degrade.
+  const target = response.target_id
+    ? neighbors.find((n) => n.id === response.target_id)
+    : undefined;
+  if (!target) {
+    warn(
+      `${response.op} target ${response.target_id ?? '(none)'} not among retrieved neighbors — demoting to ADD ("${candidate.text.slice(0, 60)}")`,
+    );
+    return addOp(candidate, response.reasoning, response.confidence, retrieval, {
+      demotedFrom: response.op,
+    });
+  }
+
+  // Confidence floor: below it, a merge verb demotes to ADD.
+  if (response.confidence < floor) {
+    warn(
+      `${response.op} confidence ${response.confidence.toFixed(2)} below floor ${floor} — demoting to ADD ("${candidate.text.slice(0, 60)}")`,
+    );
+    return addOp(candidate, response.reasoning, response.confidence, retrieval, {
+      demotedFrom: response.op,
+    });
+  }
+
+  return InsightOpSchema.parse({
+    op: response.op,
+    candidate,
+    targetInsightId: target.id,
+    targetUpdatedAt: target.updatedAt.toISOString(),
+    // UPDATE without new_text: fall back to the candidate text — the
+    // refresh IS the candidate. SUPERSEDE/NOOP carry no newText.
+    ...(response.op === 'UPDATE' ? { newText: response.new_text ?? candidate.text } : {}),
+    reasoning: response.reasoning,
+    confidence: response.confidence,
+    retrieval,
+  });
+}
+
+/**
+ * Orchestrate a scan's candidates into ops:
+ *   - entityStatus 'new' (folder-ref entityId, no uuid container yet) →
+ *     ADD + unresolvedEntity, no retrieval, no LLM. D4 resolves
+ *     folder→campaign uuid at apply.
+ *   - empty container → ADD without an LLM call.
+ *   - otherwise embed → retrieve → reconcile.
+ *
+ * Errors propagate — the flag-gated dryrun caller fails soft (a missing
+ * preset must not kill the scan print), the eval wants the throw.
+ */
+export async function reconcileCandidates(
+  candidates: CandidateInsight[],
+  opts: ReconcileOptions = {},
+): Promise<InsightOp[]> {
+  const k = opts.k ?? DEFAULT_RETRIEVAL_K;
+  const embed = opts.embed ?? embedTexts;
+  const retrieve = opts.retrieve ?? retrieveNeighbors;
+  const warn = opts.warn ?? ((m: string): void => logger.warn(`[insight-reconcile] ${m}`));
+  const emptyRetrieval = { k, neighborIds: [], distances: [] };
+
+  const ops = new Array<InsightOp>(candidates.length);
+  const retrievable: Array<{ index: number; candidate: CandidateInsight }> = [];
+
+  for (const [index, candidate] of candidates.entries()) {
+    if (candidate.entityStatus === 'new') {
+      ops[index] = addOp(
+        candidate,
+        'new-entity candidate — no store container exists yet; reconciliation bypassed',
+        candidate.confidence,
+        emptyRetrieval,
+        { unresolvedEntity: true },
+      );
+      continue;
+    }
+    if (!UUID_RE.test(candidate.entityId)) {
+      // Defensive: only 'new' candidates should carry non-uuid entityIds,
+      // but a raw `::uuid` cast on a bad id would kill the whole batch.
+      warn(
+        `non-uuid entityId "${candidate.entityId}" on ${candidate.entityStatus ?? 'existing'} ${candidate.entityType} — treating as unresolved, emitting ADD`,
+      );
+      ops[index] = addOp(
+        candidate,
+        'entityId is not a store uuid — reconciliation bypassed',
+        candidate.confidence,
+        emptyRetrieval,
+        { unresolvedEntity: true },
+      );
+      continue;
+    }
+    retrievable.push({ index, candidate });
+  }
+
+  if (retrievable.length === 0) return ops;
+
+  // One embed call for the whole scan — the batch is the unit the API bills.
+  const vectors = await embed(retrievable.map((r) => r.candidate.text));
+
+  for (const [i, { index, candidate }] of retrievable.entries()) {
+    const neighbors = await retrieve(
+      { entityType: candidate.entityType, entityId: candidate.entityId },
+      vectors[i]!,
+      k,
+    );
+    ops[index] =
+      neighbors.length === 0
+        ? addOp(
+            candidate,
+            'empty container — no active insights to reconcile against',
+            candidate.confidence,
+            emptyRetrieval,
+          )
+        : await reconcileCandidate(candidate, neighbors, { ...opts, k });
+  }
+
+  return ops;
+}


### PR DESCRIPTION
Implements D3 (#39): turn D2's candidate insights into reconciliation ops against the existing insight store.

- Embed each candidate (gemini-embedding-001 @ 1536, decision B4) → retrieve top-K (2–3) within the same `(entity_type, entity_id)` scope via raw pgvector `<=>` → reconciliation prompt → structured `ADD | UPDATE(target) | SUPERSEDE(target) | NOOP` with a confidence floor.
- `src/ai/embed.ts` (+ client wiring), `src/drive/insight-reconcile.ts`, tests.

**Stacked on D2** (`feat/d2-candidate-insights`, PR #49) — this PR's base is that branch, so the diff is just the reconciliation layer; it auto-retargets to `main` once #49 merges. **Persistence is out of scope** (that's D4, per the B1 review-gate ruling) — D3 produces validated ops, it does not write them. Known bound: NOOP-dedup quality is capped by retrieval recall (paraphrases outside top-K become ADDs) — measured against a golden set, not assumed.