### PR TITLE
chore: move co-located tests into __tests__/ dirs

### DIFF
--- a/src/drive/__tests__/extract.test.ts
+++ b/src/drive/__tests__/extract.test.ts
@@ -46,19 +46,19 @@ vi.mock('googleapis', () => ({
   },
 }));
 
-vi.mock('../workspace', () => ({
+vi.mock('../../workspace', () => ({
   buildBotOAuthClient: buildBotOAuthClientMock,
 }));
 
-vi.mock('../config', () => ({
+vi.mock('../../config', () => ({
   config: { DRIVE_MAX_FILE_SIZE_BYTES: 26214400 },
 }));
 
-vi.mock('../logger', () => ({
+vi.mock('../../logger', () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-vi.mock('./client', () => ({
+vi.mock('../client', () => ({
   downloadFileBuffer: vi.fn(),
 }));
 
@@ -80,7 +80,7 @@ import {
   extractGoogleDoc,
   extractGoogleSlides,
   extractGoogleSheets,
-} from './extract';
+} from '../extract';
 
 // ── Google Docs walker ──────────────────────────────────────────────────────
 

--- a/src/drive/__tests__/retry.test.ts
+++ b/src/drive/__tests__/retry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { isTransientTransportError, withTransientRetry } from './retry';
+import { isTransientTransportError, withTransientRetry } from '../retry';
 
 describe('isTransientTransportError', () => {
   it('accepts 5xx from Google, however the status is shaped', () => {

--- a/src/scan/__tests__/note-marker.test.ts
+++ b/src/scan/__tests__/note-marker.test.ts
@@ -3,7 +3,7 @@ import {
   hasNewCandidateMarker,
   newCandidateMarker,
   stripNewCandidateMarker,
-} from './note-marker';
+} from '../note-marker';
 
 // The marker is what partitions the shared account card: the account's own
 // notes plus one pending row per new candidate all live under one key, and


### PR DESCRIPTION
Standardizes the test layout on `__tests__/` directories (the workspace-wide convention; the newer test files on the open D2/D3 branches already follow it).

Pure `git mv` of the three co-located suites (`note-marker`, `retry`, `extract`) — the only content changes are relative import/mock paths gaining one level. No logic changes. Full suite green (21 tests).