### PR TITLE
feat(scan): emit review-gated insight_op proposals from D3 reconciliation ops (D4)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -65,12 +65,15 @@ const EnvSchema = z.object({
    */
   SYNTH_CONCURRENCY: z.string().default('8').transform(Number),
   /**
-   * D3 (#39): reconcile the scan's candidate insights against the insight
-   * store. 'off' (default) skips reconciliation entirely; 'dryrun' embeds,
-   * retrieves top-K neighbors, and prints zod-validated ops after the D2
-   * candidate print — zero DB writes in any mode (persistence is D4).
+   * D3 (#39) / D4 (#40): reconcile the scan's candidate insights against the
+   * insight store. 'off' (default) skips reconciliation entirely; 'dryrun'
+   * embeds, retrieves top-K neighbors, and prints zod-validated ops after the
+   * D2 candidate print — zero DB writes. 'propose' (forward driver only)
+   * additionally emits each non-NOOP op as a kind='insight_op'
+   * drive_change_proposal — review-gated per the B1 ruling (2026-08-19);
+   * GUB's applyDecisions writes the insights store on approval.
    */
-  INSIGHT_RECONCILE: z.enum(['off', 'dryrun']).default('off'),
+  INSIGHT_RECONCILE: z.enum(['off', 'dryrun', 'propose']).default('off'),
 
   // ── Notify URLs ──────────────────────────────────────────────────────────
   GUB_ADMIN_BASE_URL: z.string().url().default('http://localhost:5173'),

--- a/src/drive/notify.ts
+++ b/src/drive/notify.ts
@@ -166,12 +166,14 @@ export async function notifyReviewers(input: NotifyInput = {}): Promise<NotifyRe
       bucket.filter((r) => r.kind === 'new_entity' && r.proposalGroupId).map((r) => r.proposalGroupId!),
     ).size;
     const fieldChanges = bucket.filter((r) => r.kind === 'field_change').length;
+    const insightOps = bucket.filter((r) => r.kind === 'insight_op').length;
 
     const { subject, text, html } = renderReviewEmail({
       reviewerName: staff.fullName,
       magicLink,
       fieldChanges,
       newEntityGroups,
+      insightOps,
       ttlDays: config.DRIVE_PROPOSAL_TTL_DAYS,
     });
 
@@ -240,6 +242,9 @@ interface RenderInput {
   magicLink: string;
   fieldChanges: number;
   newEntityGroups: number;
+  /** D4 (#40): pending insight_op cards in the bundle. Counted so an
+   *  insight-only batch doesn't render as a contentless "items" email. */
+  insightOps: number;
   ttlDays: number;
 }
 
@@ -250,6 +255,9 @@ function renderReviewEmail(i: RenderInput): { subject: string; text: string; htm
   }
   if (i.fieldChanges > 0) {
     parts.push(`${i.fieldChanges} ${i.fieldChanges === 1 ? 'change' : 'changes'}`);
+  }
+  if (i.insightOps > 0) {
+    parts.push(`${i.insightOps} insight ${i.insightOps === 1 ? 'update' : 'updates'}`);
   }
   const summary = parts.length > 0 ? parts.join(' and ') : 'items';
   const subject = `Drive sync: ${summary} need your review`;

--- a/src/forward/run.ts
+++ b/src/forward/run.ts
@@ -27,6 +27,9 @@ import { resetPhaseTimer, printPhaseSummary, timed } from '../scan/timing';
 import { queryActivityWindow, foldEvents, ymdUtc } from './activity';
 import { resolveActors } from './people';
 import { writeRunEditStats } from './stats';
+import { config } from '../config';
+import { reconcileCandidates } from '../drive/insight-reconcile';
+import { proposeInsightOps } from '../scan/propose';
 
 /** Absorbs Activity API ingestion lag at the window edge (design Q4). */
 const OVERLAP_MS = 2 * 60 * 1000;
@@ -226,6 +229,40 @@ async function runForwardInner(fargs: ForwardArgs): Promise<BackfillRunResult> {
         `${outcome.stage3Failures} stage-3 failure(s) — cursor NOT advanced; retry re-runs this window`,
       );
     }
+
+    // D4 (#40): flag-gated insight-op emit — reconcile the window's
+    // candidates (D3) and propose each non-NOOP op as a review-gated
+    // insight_op card (B1 ruling). Fail-soft ON PURPOSE, unlike the field
+    // proposals above: insights are an additive dark-launched tier, and a
+    // reconcile/emit failure (missing preset, embed outage) must not stall
+    // the forward cursor for the main proposal pipeline. The cost of a
+    // missed window is bounded — the candidates' facts resurface when the
+    // entity's docs next change, and D5's seed/backfill replays history.
+    if (config.INSIGHT_RECONCILE === 'propose' && outcome.candidates.length > 0) {
+      try {
+        const ops = await timed('insight_reconcile', () =>
+          reconcileCandidates(outcome.candidates, {
+            warn: (m) => log(`  ⚠ ${m}`),
+          }),
+        );
+        const res = await proposeInsightOps({
+          ops,
+          reviewer: {
+            reviewerEmail: ctx.reviewerEmail ?? null,
+            reviewerStaffId: ctx.reviewerStaffId ?? null,
+          },
+          syncRunId: fargs.syncRunId,
+        });
+        log(
+          `  ◆ insight ops: ${res.emitted} proposed, ${res.duplicatesSkipped} already pending, ${res.noops} NOOP — from ${outcome.candidates.length} candidate(s)`,
+        );
+      } catch (err) {
+        log(
+          `  ⚠ insight-op emit failed (window still commits; facts re-surface on next doc change): ${summarizeError(err)}`,
+        );
+      }
+    }
+
     filesProcessed = files.length;
     scansProcessed = 1;
   }

--- a/src/scan/__tests__/propose.insight-op.test.ts
+++ b/src/scan/__tests__/propose.insight-op.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Hermetic suite for the D4 (#40) insight_op emit path (scan/propose.ts).
+ *
+ * The pure pieces (op hash, payload builder) are tested directly; the DB
+ * writer runs against a hoisted fake prisma (module-boundary mock), so the
+ * dedup guard and the fail-soft embedding path are exercised without a DB.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const F = vi.hoisted(() => {
+  const state = {
+    pendingMatch: null as null | { id: string },
+    findFirstCalls: [] as unknown[],
+    created: [] as Array<Record<string, unknown>>,
+  };
+  const prismaFake = {
+    driveChangeProposal: {
+      findFirst: async (args: unknown) => {
+        state.findFirstCalls.push(args);
+        return state.pendingMatch;
+      },
+      create: async ({ data }: { data: Record<string, unknown> }) => {
+        state.created.push(data);
+        return { id: `created-${state.created.length}`, ...data };
+      },
+    },
+  };
+  return { state, prismaFake };
+});
+
+vi.mock('../../prisma', () => ({ prisma: F.prismaFake }));
+vi.mock('../../config', () => ({ config: { DRIVE_PROPOSAL_TTL_DAYS: 14 } }));
+vi.mock('../output', () => ({ log: vi.fn() }));
+vi.mock('../../ai', () => ({
+  embedTexts: vi.fn(async (texts: string[]) => texts.map((_, i) => [i + 0.5, i + 1.5])),
+  // insight-reconcile (imported for InsightOpSchema) reads these at module
+  // top level — stubs only, nothing here ever calls them.
+  SchemaType: { OBJECT: 'OBJECT', STRING: 'STRING', NUMBER: 'NUMBER' },
+  runPreset: vi.fn(),
+  parseLlmJson: vi.fn(),
+}));
+
+import { Prisma } from '@prisma/client';
+import { embedTexts } from '../../ai';
+import { InsightOpSchema, type InsightOp } from '../../drive/insight-reconcile';
+import {
+  buildInsightOpProposal,
+  insightOpFinalText,
+  insightOpHash,
+  proposeInsightOps,
+} from '../propose';
+
+const ACCOUNT = 'aaaaaaaa-0000-4000-8000-000000000001';
+const CAMPAIGN = 'bbbbbbbb-0000-4000-8000-000000000002';
+const TARGET = 'cccccccc-0000-4000-8000-000000000003';
+
+function makeOp(overrides: Partial<InsightOp> = {}): InsightOp {
+  return InsightOpSchema.parse({
+    op: 'ADD',
+    candidate: {
+      accountId: ACCOUNT,
+      entityType: 'account',
+      entityId: ACCOUNT,
+      text: 'Acme prefers Q4 launches',
+      sourceFileIds: ['file-1'],
+      confidence: 0.9,
+      origin: 'note',
+    },
+    reasoning: 'fresh fact',
+    confidence: 0.9,
+    retrieval: { k: 3, neighborIds: [], distances: [] },
+    ...overrides,
+  });
+}
+
+function makeUpdateOp(overrides: Partial<InsightOp> = {}): InsightOp {
+  return makeOp({
+    op: 'UPDATE',
+    targetInsightId: TARGET,
+    targetUpdatedAt: '2026-08-27T10:00:00.000Z',
+    newText: 'Acme prefers Q4 launches (confirmed for 2026)',
+    retrieval: { k: 3, neighborIds: [TARGET], distances: [0.12] },
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  F.state.pendingMatch = null;
+  F.state.findFirstCalls = [];
+  F.state.created = [];
+  vi.mocked(embedTexts).mockClear();
+});
+
+// ── insightOpHash ────────────────────────────────────────────────────────────
+
+describe('insightOpHash', () => {
+  it('ignores volatile fields — same logical op hashes identically across scans', () => {
+    const a = makeUpdateOp();
+    const b = makeUpdateOp({
+      confidence: 0.61,
+      reasoning: 'totally different wording this run',
+      targetUpdatedAt: '2026-08-28T09:00:00.000Z', // fresher CAS snapshot
+      retrieval: { k: 3, neighborIds: [TARGET, ACCOUNT], distances: [0.2, 0.4] },
+    });
+    expect(insightOpHash(a)).toBe(insightOpHash(b));
+  });
+
+  it('changes when the semantic content changes', () => {
+    const base = makeUpdateOp();
+    expect(insightOpHash(makeUpdateOp({ newText: 'different merge' }))).not.toBe(
+      insightOpHash(base),
+    );
+    expect(insightOpHash(makeOp())).not.toBe(insightOpHash(base)); // different verb
+    const otherTarget = makeUpdateOp({
+      targetInsightId: 'dddddddd-0000-4000-8000-000000000004',
+      retrieval: { k: 3, neighborIds: ['dddddddd-0000-4000-8000-000000000004'], distances: [0.3] },
+    });
+    expect(insightOpHash(otherTarget)).not.toBe(insightOpHash(base));
+  });
+});
+
+// ── final text ───────────────────────────────────────────────────────────────
+
+describe('insightOpFinalText', () => {
+  it('UPDATE uses newText (falling back to the candidate text)', () => {
+    expect(insightOpFinalText(makeUpdateOp())).toBe(
+      'Acme prefers Q4 launches (confirmed for 2026)',
+    );
+  });
+  it('ADD/SUPERSEDE use the candidate text', () => {
+    expect(insightOpFinalText(makeOp())).toBe('Acme prefers Q4 launches');
+  });
+});
+
+// ── buildInsightOpProposal ───────────────────────────────────────────────────
+
+describe('buildInsightOpProposal', () => {
+  it('shapes an ADD account op', () => {
+    const row = buildInsightOpProposal(makeOp(), [0.1, 0.2]);
+    expect(row).toMatchObject({
+      kind: 'insight_op',
+      entityType: 'account',
+      accountId: ACCOUNT,
+      campaignId: null,
+      property: '__insight_op__',
+    });
+    expect(row.proposedValue).toMatchObject({
+      op: 'ADD',
+      opHash: row.opHash,
+      embedding: [0.1, 0.2],
+    });
+    expect(row.proposedValue).not.toHaveProperty('targetInsightId');
+    expect(row.proposedValue).not.toHaveProperty('newText');
+  });
+
+  it('shapes an UPDATE against an existing campaign (campaignId set)', () => {
+    const op = makeUpdateOp({
+      candidate: {
+        accountId: ACCOUNT,
+        entityType: 'campaign',
+        entityId: CAMPAIGN,
+        entityStatus: 'existing',
+        text: 'campaign shifted to October',
+        sourceFileIds: ['file-2'],
+        confidence: 0.8,
+        origin: 'note',
+      },
+      newText: 'campaign shifted to October (was September)',
+    });
+    const row = buildInsightOpProposal(op, null);
+    expect(row.entityType).toBe('campaign');
+    expect(row.campaignId).toBe(CAMPAIGN);
+    expect(row.accountId).toBe(ACCOUNT);
+    expect(row.proposedValue).toMatchObject({
+      targetInsightId: TARGET,
+      targetUpdatedAt: '2026-08-27T10:00:00.000Z',
+      newText: 'campaign shifted to October (was September)',
+    });
+    expect(row.proposedValue).not.toHaveProperty('embedding'); // null → omitted
+  });
+
+  it('anchors an unresolved new-campaign candidate on the account', () => {
+    const op = makeOp({
+      candidate: {
+        accountId: ACCOUNT,
+        entityType: 'campaign',
+        entityId: 'drive-folder-ref-123', // folder ref, not a store uuid
+        entityStatus: 'new',
+        text: 'kickoff planned for September',
+        sourceFileIds: ['file-3'],
+        confidence: 0.7,
+        origin: 'note',
+      },
+      unresolvedEntity: true,
+    });
+    const row = buildInsightOpProposal(op, null);
+    expect(row.campaignId).toBeNull(); // no campaign row yet — CHECK-safe
+    expect(row.accountId).toBe(ACCOUNT);
+    expect(row.proposedValue).toMatchObject({ unresolvedEntity: true });
+    expect((row.proposedValue.candidate as { entityId: string }).entityId).toBe(
+      'drive-folder-ref-123',
+    );
+  });
+});
+
+// ── proposeInsightOps (DB writer against the fake) ───────────────────────────
+
+describe('proposeInsightOps', () => {
+  const reviewer = { reviewerEmail: 'owner@example.test', reviewerStaffId: 'staff-1' };
+  const SYNC_RUN = 'eeeeeeee-0000-4000-8000-000000000005';
+
+  it('NOOP ops never become cards', async () => {
+    const noop = makeOp({
+      op: 'NOOP',
+      targetInsightId: TARGET,
+      targetUpdatedAt: '2026-08-27T10:00:00.000Z',
+      retrieval: { k: 3, neighborIds: [TARGET], distances: [0.05] },
+    });
+    const res = await proposeInsightOps({ ops: [noop], reviewer, syncRunId: SYNC_RUN });
+    expect(res).toEqual({ emitted: 0, duplicatesSkipped: 0, noops: 1 });
+    expect(F.state.created).toHaveLength(0);
+    expect(embedTexts).not.toHaveBeenCalled(); // nothing to embed
+  });
+
+  it('emits a proposal row with run provenance, reviewer, TTL and one batch embed call', async () => {
+    const ops = [makeOp(), makeUpdateOp()];
+    const before = Date.now();
+    const res = await proposeInsightOps({ ops, reviewer, syncRunId: SYNC_RUN });
+
+    expect(res).toEqual({ emitted: 2, duplicatesSkipped: 0, noops: 0 });
+    expect(embedTexts).toHaveBeenCalledTimes(1); // one call for the batch
+    expect(vi.mocked(embedTexts).mock.calls[0]![0]).toEqual([
+      'Acme prefers Q4 launches',
+      'Acme prefers Q4 launches (confirmed for 2026)',
+    ]);
+
+    const row = F.state.created[0]!;
+    expect(row).toMatchObject({
+      kind: 'insight_op',
+      state: 'pending',
+      syncRunId: SYNC_RUN, // attached at emit — not on the op (D3 contract)
+      reviewerEmail: 'owner@example.test',
+      reviewerStaffId: 'staff-1',
+    });
+    expect((row.confidence as Prisma.Decimal).toNumber()).toBeCloseTo(0.9);
+    expect(row.reviewToken).toMatch(/^[0-9a-f]{64}$/);
+    const expires = (row.expiresAt as Date).getTime();
+    expect(expires).toBeGreaterThan(before + 13 * 86_400_000);
+    expect(expires).toBeLessThan(before + 15 * 86_400_000);
+    // Each op got ITS vector, not the batch's first.
+    expect((row.proposedValue as { embedding: number[] }).embedding).toEqual([0.5, 1.5]);
+    expect(
+      (F.state.created[1]!.proposedValue as { embedding: number[] }).embedding,
+    ).toEqual([1.5, 2.5]);
+  });
+
+  it('skips an op with an identical pending card, keyed on (entity, op-hash)', async () => {
+    F.state.pendingMatch = { id: 'already-pending' };
+    const op = makeOp();
+    const res = await proposeInsightOps({ ops: [op], reviewer, syncRunId: SYNC_RUN });
+
+    expect(res).toEqual({ emitted: 0, duplicatesSkipped: 1, noops: 0 });
+    expect(F.state.created).toHaveLength(0);
+    const where = (F.state.findFirstCalls[0] as { where: Record<string, unknown> }).where;
+    expect(where).toMatchObject({
+      kind: 'insight_op',
+      entityType: 'account',
+      accountId: ACCOUNT,
+      campaignId: null,
+      state: 'pending',
+      proposedValue: { path: ['opHash'], equals: insightOpHash(op) },
+    });
+  });
+
+  it('fail-soft: an embedding outage still emits cards, just without vectors', async () => {
+    const res = await proposeInsightOps({
+      ops: [makeOp()],
+      reviewer,
+      syncRunId: SYNC_RUN,
+      embed: async () => {
+        throw new Error('embedding quota exhausted');
+      },
+    });
+    expect(res.emitted).toBe(1);
+    expect(F.state.created[0]!.proposedValue).not.toHaveProperty('embedding');
+  });
+});

--- a/src/scan/propose.ts
+++ b/src/scan/propose.ts
@@ -28,6 +28,8 @@ import { log } from './output';
 import type { ValidatedChange } from './persist';
 import type { EntityCtx } from './batch-types';
 import { newCandidateMarker } from './note-marker';
+import { embedTexts } from '../ai';
+import type { InsightOp } from '../drive/insight-reconcile';
 
 export interface ProposeNoteItem {
   text: string;
@@ -209,6 +211,202 @@ export async function loadPendingNoteTexts(args: {
     }
   }
   return texts;
+}
+
+// ── insight_op proposals (D4 #40) ────────────────────────────────────────────
+//
+// Each non-NOOP D3 reconciliation op becomes ONE kind='insight_op'
+// drive_change_proposals row — review-gated per the B1 ruling (2026-08-19):
+// forward PROPOSES, review APPLIES. GUB's applyDecisions consumes the
+// proposed_value payload (parseInsightOpPayload on its side is the wire
+// contract) and writes insights + insight_changes transactionally on approve.
+// NOOP ops never become cards — they're telemetry at most (pitfall #7).
+
+/**
+ * Stable identity of an op for dedup + the day-one idempotency key.
+ *
+ * Hashes the op's SEMANTIC content only: verb, container scope, target id and
+ * final text. Volatile fields are deliberately excluded — confidence /
+ * reasoning / retrieval vary run to run for the same logical op, and
+ * targetUpdatedAt is the CAS snapshot, not identity (a re-scan that re-derives
+ * the same op against a moved target must still dedup against the pending
+ * card; a stale card self-heals at approve time via reject-and-regenerate).
+ */
+export function insightOpHash(op: InsightOp): string {
+  const canonical = JSON.stringify({
+    op: op.op,
+    entityType: op.candidate.entityType,
+    entityId: op.candidate.entityId,
+    targetInsightId: op.targetInsightId ?? null,
+    newText: op.op === 'UPDATE' ? op.newText ?? op.candidate.text : null,
+    text: op.candidate.text,
+  });
+  return crypto.createHash('sha256').update(canonical).digest('hex');
+}
+
+/** The op's final insight text — what lands in the store on approval
+ *  (and therefore what gets embedded). */
+export function insightOpFinalText(op: InsightOp): string {
+  return op.op === 'UPDATE' ? op.newText ?? op.candidate.text : op.candidate.text;
+}
+
+export interface InsightOpProposalRow {
+  kind: 'insight_op';
+  entityType: 'account' | 'campaign';
+  accountId: string;
+  campaignId: string | null;
+  property: string;
+  proposedValue: Record<string, unknown>;
+  reasoning: string;
+  sourceFileIds: string[];
+  confidence: number;
+  opHash: string;
+}
+
+/**
+ * Pure payload assembly (hermetic-suite seam — the DB writer below stays
+ * thin). `embedding` is the final text's vector, computed by the caller in
+ * one batch; GUB has no embedding stack, so the vector rides the proposal.
+ */
+export function buildInsightOpProposal(
+  op: InsightOp,
+  embedding: number[] | null,
+): InsightOpProposalRow {
+  const c = op.candidate;
+  const opHash = insightOpHash(op);
+  // An unresolved new-campaign candidate has a Drive folder ref as entityId —
+  // no campaign row yet, so the proposal anchors on the account (the CHECK
+  // requires an entity ref); GUB resolves folder → campaign id at approve.
+  const campaignId =
+    c.entityType === 'campaign' && c.entityStatus !== 'new' && !op.unresolvedEntity
+      ? c.entityId
+      : null;
+  return {
+    kind: 'insight_op',
+    entityType: c.entityType,
+    accountId: c.accountId,
+    campaignId,
+    // Sentinel — `property` is NOT NULL but names no column for this kind
+    // (same contract as additional_update's '__note__').
+    property: '__insight_op__',
+    proposedValue: {
+      op: op.op,
+      ...(op.targetInsightId !== undefined ? { targetInsightId: op.targetInsightId } : {}),
+      ...(op.targetUpdatedAt !== undefined ? { targetUpdatedAt: op.targetUpdatedAt } : {}),
+      ...(op.op === 'UPDATE' ? { newText: op.newText ?? c.text } : {}),
+      opHash,
+      ...(embedding ? { embedding } : {}),
+      candidate: c,
+      ...(op.unresolvedEntity ? { unresolvedEntity: true } : {}),
+      ...(op.demotedFrom !== undefined ? { demotedFrom: op.demotedFrom } : {}),
+      // Telemetry for apply-side debugging + the eval; never prompt input.
+      retrieval: op.retrieval,
+    },
+    reasoning: op.reasoning,
+    sourceFileIds: c.sourceFileIds,
+    confidence: op.confidence,
+    opHash,
+  };
+}
+
+export interface ProposeInsightOpsInput {
+  ops: InsightOp[];
+  reviewer: { reviewerEmail: string | null; reviewerStaffId: string | null };
+  /** Attached at emit — the op itself carries no run provenance (D3 contract). */
+  syncRunId: string;
+  /** Injectable seam: embedding client (fail-soft — see below). */
+  embed?: (texts: string[]) => Promise<number[][]>;
+}
+
+export interface ProposeInsightOpsResult {
+  emitted: number;
+  /** Ops skipped because an identical pending insight_op card exists. */
+  duplicatesSkipped: number;
+  noops: number;
+}
+
+export async function proposeInsightOps(
+  input: ProposeInsightOpsInput,
+): Promise<ProposeInsightOpsResult> {
+  const embed = input.embed ?? embedTexts;
+  const expiresAt = new Date(
+    Date.now() + config.DRIVE_PROPOSAL_TTL_DAYS * 24 * 60 * 60 * 1000,
+  );
+
+  const emittable = input.ops.filter((op) => op.op !== 'NOOP');
+  const noops = input.ops.length - emittable.length;
+  if (emittable.length === 0) {
+    return { emitted: 0, duplicatesSkipped: 0, noops };
+  }
+
+  // One embed call for the batch (the batch is the unit the API bills).
+  // Fail-soft: a proposal without a vector is still reviewable/appliable —
+  // GUB warns at apply and the row stays invisible to retrieval until
+  // re-embedded. Losing the card entirely would be worse.
+  let vectors: Array<number[] | null>;
+  try {
+    vectors = await embed(emittable.map((op) => insightOpFinalText(op)));
+  } catch (err) {
+    log(
+      `      ⚠ insight-op embedding failed — proposing without vectors: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    vectors = emittable.map(() => null);
+  }
+
+  let emitted = 0;
+  let duplicatesSkipped = 0;
+  for (const [i, op] of emittable.entries()) {
+    const row = buildInsightOpProposal(op, vectors[i] ?? null);
+
+    // Re-propose guard (the A1 duplicate-card lesson), keyed on
+    // (entity, op-hash): an identical pending card means the reviewer
+    // already has this op — every scan until they decide would stack
+    // another copy. The hash ignores volatile fields, so a re-derived op
+    // with only a fresher CAS snapshot still counts as identical; a stale
+    // pending card self-heals at approve (reject-as-stale → re-propose).
+    const pending = await prisma.driveChangeProposal.findFirst({
+      where: {
+        kind: 'insight_op',
+        entityType: row.entityType,
+        accountId: row.accountId,
+        campaignId: row.campaignId,
+        state: 'pending',
+        proposedValue: { path: ['opHash'], equals: row.opHash },
+      },
+      select: { id: true },
+    });
+    if (pending) {
+      duplicatesSkipped++;
+      continue;
+    }
+
+    await prisma.driveChangeProposal.create({
+      data: {
+        kind: row.kind,
+        entityType: row.entityType,
+        accountId: row.accountId,
+        campaignId: row.campaignId,
+        property: row.property,
+        currentValue: Prisma.JsonNull,
+        proposedValue: row.proposedValue as unknown as Prisma.InputJsonValue,
+        reasoning: row.reasoning,
+        sourceFileIds: row.sourceFileIds,
+        confidence: new Prisma.Decimal(row.confidence),
+        state: 'pending',
+        reviewToken: crypto.randomBytes(32).toString('hex'),
+        reviewerEmail: input.reviewer.reviewerEmail,
+        reviewerStaffId: input.reviewer.reviewerStaffId,
+        expiresAt,
+        syncRunId: input.syncRunId,
+      },
+    });
+    emitted++;
+  }
+
+  log(
+    `      → insight ops proposed for review: ${emitted}${duplicatesSkipped > 0 ? ` (${duplicatesSkipped} already pending)` : ''}${noops > 0 ? `, ${noops} NOOP (no card)` : ''}`,
+  );
+  return { emitted, duplicatesSkipped, noops };
 }
 
 async function writeNoteBatch(args: {


### PR DESCRIPTION
The emit half of #40 (D4), stacked on `feat/d3-insight-reconcile` (#52 ← #49) — the diff shown here is against that branch. The apply half is bpriddy/gcp-universal-backend#63. Per the B1 ruling (#30): each non-NOOP D3 reconciliation op becomes ONE `kind='insight_op'` `drive_change_proposals` row consumed by GUB's `applyDecisions`; **NOOP never becomes a card** (telemetry log line only).

## Changes

- `config`: `INSIGHT_RECONCILE` gains `'propose'` (forward driver only; backfill keeps `dryrun` — bootstrap persistence is D5).
- `scan/propose.ts`:
  - `insightOpHash` — sha-256 over the op's **semantic** content only (verb, entity scope, target id, final text). Volatile fields (confidence / reasoning / retrieval / `targetUpdatedAt`) are excluded, so a re-derived op whose only difference is a fresher CAS snapshot still dedups against the pending card; a stale pending card self-heals at approve time (reject-as-stale → re-propose).
  - `buildInsightOpProposal` (pure, hermetically tested) — payload = `{ op, targetInsightId?, targetUpdatedAt?, newText?, opHash, embedding?, candidate, unresolvedEntity?, demotedFrom?, retrieval }`. An unresolved new-campaign candidate anchors on the account (no campaign row yet — CHECK-safe); GUB resolves folder → campaign id at approve.
  - `proposeInsightOps` — re-propose guard keyed on (entity, op-hash) against pending cards (the A1 duplicate-card lesson); `syncRunId` attached at emit (the op itself carries no run provenance, per the D3 contract); ONE batch embed call over the ops' final texts, the vectors ride the payload (GUB has no embedding stack). Embed outage is **fail-soft**: the card ships without a vector (GUB warns at apply) — losing the card entirely would be worse.
- `forward/run.ts`: after the stage-3 window-commit gate — reconcile the window's candidates (D3) → propose. **Fail-soft on purpose**, unlike the field proposals: insights are an additive dark-launched tier and a reconcile/emit failure (missing preset, embed outage) must not stall the forward cursor for the main proposal pipeline. The bounded cost is documented inline (facts resurface on the next doc change; D5's seed/backfill replays history).
- `notify.ts`: the review email counts insight cards, so an insight-only batch doesn't render as a contentless "items" email.

## Verification

- `tsc` clean; 70 tests green — 11 new: hash identity across volatile-field changes / sensitivity to semantic changes, payload shapes per op kind incl. unresolved new-campaign anchoring, the dedup guard's where-clause (JSON-path on `opHash`), NOOP suppression, provenance/TTL/token shape, one-batch embedding with per-op vectors, fail-soft embedding.

## Rollout

Flip `INSIGHT_RECONCILE=propose` only after the whole stack is merged and deployed: bpriddy/gcp-universal-backend#62 → Anomaly-Technology/gcp-universal-schemas#3 → #6 (publish 1.2.0) → bpriddy/gcp-universal-backend#63 → #49 → #52 → this.
