### PR TITLE
chore: two-tier git hooks (pre-commit secrets+lint, pre-push typecheck+tests)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,55 @@
+#!/bin/sh
+#
+# GUB pre-commit hook — fast, staged-only. Keep commits instant; the heavy
+# checks (typecheck, tests) run in pre-push.
+#
+#   1. gitleaks     — block secrets from ever landing
+#   2. eslint       — lint staged src/ JS-TS (check only, no auto-fix)
+#   3. prettier     — codestyle check on staged JS-TS
+#   4. lint:schema  — validate prisma/schema.prisma when it is staged
+#
+# Setup is auto-wired by the package.json "prepare" script on `npm install`,
+# or run once manually:
+#
+#   git config core.hooksPath .githooks
+#
+# Escape hatch for a one-off commit (justify it in the message):
+#
+#   git commit --no-verify           # skip every hook
+#   SKIP_GITLEAKS=1 git commit ...   # skip only the secret scan
+
+set -e
+
+# ---- 1. secrets -----------------------------------------------------------
+if [ "$SKIP_GITLEAKS" = "1" ]; then
+  echo "gitleaks: skipped via SKIP_GITLEAKS=1" >&2
+elif command -v gitleaks >/dev/null 2>&1; then
+  gitleaks git --staged --redact --no-banner
+else
+  echo "gitleaks not installed — refusing to commit." >&2
+  echo "  install: https://github.com/gitleaks/gitleaks#installation" >&2
+  echo "  bypass:  SKIP_GITLEAKS=1 git commit ..." >&2
+  exit 1
+fi
+
+# ---- 2/3. staged lint + codestyle (skips cleanly if deps not installed) ---
+CODE=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.(ts|tsx|js|jsx|mjs|cjs)$' || true)
+if [ -n "$CODE" ]; then
+  SRC=$(printf '%s\n' "$CODE" | grep -E '^(src|scripts)/' || true)
+  if [ -n "$SRC" ] && [ -x node_modules/.bin/eslint ]; then
+    echo "pre-commit: eslint (staged)"
+    printf '%s\n' "$SRC" | xargs node_modules/.bin/eslint
+  fi
+  if [ -x node_modules/.bin/prettier ]; then
+    echo "pre-commit: prettier --check (staged)"
+    printf '%s\n' "$CODE" | xargs node_modules/.bin/prettier --check
+  fi
+fi
+
+# ---- 4. schema lint when the canonical schema is staged -------------------
+if git diff --cached --name-only --diff-filter=ACMR | grep -q 'prisma/schema.prisma'; then
+  if node -e "process.exit((require('./package.json').scripts||{})['lint:schema']?0:1)" 2>/dev/null; then
+    echo "pre-commit: lint:schema"
+    npm run --silent lint:schema
+  fi
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# GUB pre-push hook — heavy checks, runs on push (not on every commit) so type
+# errors and red tests never leave the branch, while commits stay instant.
+#
+#   - typecheck  (tsc --noEmit)
+#   - test suite (where the repo has one)
+#   - lint:schema / schema checks (schema repo)
+#
+# Skipped entirely until `npm install` has been run (CI still enforces).
+# Bypass a blocked push (justify it): git push --no-verify
+
+set -e
+
+if [ ! -d node_modules ]; then
+  echo "pre-push: node_modules missing — run 'npm install' to enable typecheck/tests (skipping)." >&2
+  exit 0
+fi
+
+has() { node -e "process.exit((require('./package.json').scripts||{})['$1']?0:1)" 2>/dev/null; }
+
+if has typecheck; then
+  echo "pre-push: npm run typecheck"
+  npm run --silent typecheck
+fi
+if has test; then
+  echo "pre-push: npm test"
+  npm test
+fi
+if has lint:schema; then
+  echo "pre-push: npm run lint:schema"
+  npm run --silent lint:schema
+fi

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "probe-revision-content": "tsx -r dotenv/config scripts/probe-revision-content.ts",
     "lint": "eslint src",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "prepare": "git config core.hooksPath .githooks || true"
   },
   "dependencies": {
     "@google/genai": "^2.11.0",


### PR DESCRIPTION
Shared two-tier git hooks (extends the existing `.githooks/` + gitleaks pattern; no husky/lint-staged).

**pre-commit** (fast, staged-only — keeps commits instant):
- gitleaks secret scan
- `eslint` + `prettier --check` on staged `src/`/`scripts/` JS-TS (`ruff check` + `ruff format --check` for gub-agent)
- `lint:schema` when `prisma/schema.prisma` is staged

**pre-push** (heavy checks, so type errors / red tests never leave the branch):
- `typecheck` (`tsc --noEmit`) + test suite where present (`ruff check .` + `pytest` for gub-agent)
- whole hook is a no-op until `npm install` has run; bypass a blocked push with `git push --no-verify`

**Activation:** auto-wires on `npm install` via a `package.json` `"prepare"` script (`git config core.hooksPath .githooks`). A `typecheck` npm script was added where missing.

**Escape hatches:** `git commit/push --no-verify`, `SKIP_GITLEAKS=1 git commit`.