### PR TITLE
logs: structured JSON on Cloud Run regardless of NODE_ENV

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -9,8 +9,13 @@ const level = process.env['LOG_LEVEL'] ?? 'info';
 const nodeEnv = process.env['NODE_ENV'];
 const isGcp = Boolean(process.env['GCP_PROJECT_ID']);
 const isProduction = nodeEnv === 'production';
+// Cloud Run sets CLOUD_RUN_JOB (jobs) / K_SERVICE (services). A deployed
+// runtime must log structured JSON regardless of NODE_ENV — gating on
+// NODE_ENV alone made pretty ANSI logs possible on Cloud Run (the exact
+// bug gcp-universal-backend hit on its dev service).
+const onCloudRun = Boolean(process.env['CLOUD_RUN_JOB'] ?? process.env['K_SERVICE']);
 
-export const logger = isProduction && isGcp
+export const logger = onCloudRun || (isProduction && isGcp)
   ? pino({
       level,
       messageKey: 'message',


### PR DESCRIPTION
Port of gcp-universal-backend#71. The logger's GCP-structured branch was gated on `NODE_ENV=production` — correct today (the job runs production), but the same latent trap that bit GUB's dev service: any Cloud Run runtime started with a different NODE_ENV would emit pino-pretty ANSI text (one log call splintered into many `textPayload` lines; `jsonPayload` queries impossible). Gate on `CLOUD_RUN_JOB`/`K_SERVICE` instead — set by Cloud Run itself, can't be misconfigured. No behavior change for the currently deployed job.