### PR TITLE
feat: seed/backfill the insight store from status_markdown dossiers (D5 #41)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run",
     "seed:status": "tsx -r dotenv/config scripts/seed-status-proposal.ts",
     "seed:new-entity": "tsx -r dotenv/config scripts/seed-new-entity-proposal.ts",
+    "seed:insights": "tsx -r dotenv/config scripts/seed-insights.ts",
     "backfill": "tsx -r dotenv/config src/backfill/index.ts",
     "clear": "tsx -r dotenv/config scripts/clear.ts",
     "merge-campaign-dupes": "tsx -r dotenv/config src/main.ts merge-campaign-dupes",

--- a/scripts/seed-insights.ts
+++ b/scripts/seed-insights.ts
@@ -1,0 +1,428 @@
+/**
+ * seed-insights.ts — D5 (#41): one-shot, idempotent backfill of the insight
+ * store from each entity's status_markdown dossier.
+ *
+ * Per entity: parse the stored dossier pair (## Context + surviving
+ * ## Transient bullets, general + sensitive tiers) into discrete facts →
+ * shape as D2 candidates → reconcile against the store container → apply
+ * the resulting ADD ops DIRECTLY to insights + insight_changes. Each
+ * bullet's `[src: ...]` citation is hoisted into the candidate's
+ * sourceFileIds (real Drive provenance, stripped from the fact text);
+ * markerless bullets fall back to a `status_markdown:<type>:<id>` dossier
+ * sentinel so provenance is never empty (A1).
+ *
+ * Direct write, NOT the review gate: a whole-dossier backfill would flood
+ * the reviewer with hundreds of insight_op cards — the B1 gate is for live
+ * deltas, not the one-time bootstrap. The audit row is still written —
+ * insight_changes(op:'ADD', created_by = DRIVE_SYNC_SYSTEM_STAFF_ID) — so
+ * the D6 invariant replay(insight_changes) == snapshot(insights) holds over
+ * seeded rows. Seed rows carry sync_run_id = NULL and op_hash = NULL (no
+ * run, no proposal card; the UNIQUE (sync_run_id, op_hash) key treats NULLs
+ * as distinct — see InsightChange in gub-schemas).
+ *
+ * Idempotency is deterministic, not LLM-dependent: before reconciling, any
+ * candidate whose exact text already exists as an ACTIVE insight in its
+ * container is dropped as a NOOP. A re-run over an unchanged dossier
+ * re-derives identical texts → all NOOP → zero new rows, zero Gemini calls.
+ * Only near-duplicates (a store that drifted via live scans) reach
+ * embed → retrieve → LLM reconcile — which needs the
+ * drive.insight_reconcile.v1 preset — and of those ops ONLY ADDs are
+ * applied: the seed never mutates existing insights (UPDATE/SUPERSEDE/NOOP
+ * are logged and skipped; live reconciliation owns merges).
+ *
+ * Usage:
+ *   npm run seed:insights -- --all [--dry-run]
+ *   npm run seed:insights -- --account-id <uuid> [--dry-run]
+ *   npm run seed:insights -- --campaign-id <uuid> [--dry-run]
+ *
+ * Flags:
+ *   --account-id <uuid>   Seed this account's container AND all its
+ *                         campaigns' containers (the per-account unit the
+ *                         backfill is grouped/logged by).
+ *   --campaign-id <uuid>  Seed one campaign container.
+ *   --all                 Every account + campaign with a stored dossier.
+ *   --dry-run             Parse + validate + diff against the store; print
+ *                         each candidate as would-seed / already-present.
+ *                         No writes, no Gemini calls (reconcile is skipped,
+ *                         so near-duplicates print as would-seed even when
+ *                         a real run would merge-skip them).
+ *   --as-of <YYYY-MM-DD>  Transient-expiry cutoff (default: today).
+ *
+ * Pieces (campaign_pieces.status_markdown) are deliberately out of scope —
+ * piece/idea insights are the separate idea-extraction tier (D2 ruling),
+ * and the candidate contract is account|campaign only.
+ */
+import crypto from 'node:crypto';
+import { prisma } from '../src/prisma';
+import { embedTexts } from '../src/ai';
+import {
+  toCandidateInsights,
+  type CandidateInsight,
+  type CandidateTarget,
+} from '../src/drive/candidate-insight';
+import { dossierFacts, dossierSourceId } from '../src/drive/dossier-facts';
+import { DRIVE_SYNC_SYSTEM_STAFF_ID } from '../src/drive/heal';
+import { reconcileCandidates, type InsightOp } from '../src/drive/insight-reconcile';
+
+interface Args {
+  accountId?: string;
+  campaignId?: string;
+  all: boolean;
+  dryRun: boolean;
+  asOfDate: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const get = (flag: string): string | undefined => {
+    const i = argv.indexOf(flag);
+    return i >= 0 ? argv[i + 1] : undefined;
+  };
+
+  const accountId = get('--account-id');
+  const campaignId = get('--campaign-id');
+  const all = argv.includes('--all');
+  const targets = [accountId, campaignId, all ? '--all' : undefined].filter(Boolean);
+  if (targets.length !== 1) {
+    throw new Error('Pass exactly one of --account-id <uuid>, --campaign-id <uuid>, --all');
+  }
+
+  const asOfDate = get('--as-of') ?? new Date().toISOString().slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(asOfDate)) {
+    throw new Error('--as-of must be YYYY-MM-DD');
+  }
+
+  const out: Args = { all, dryRun: argv.includes('--dry-run'), asOfDate };
+  if (accountId) out.accountId = accountId;
+  if (campaignId) out.campaignId = campaignId;
+  return out;
+}
+
+// ── Entity collection ────────────────────────────────────────────────────────
+
+interface SeedEntity {
+  accountId: string;
+  accountName: string;
+  entityType: 'account' | 'campaign';
+  entityId: string;
+  entityName: string;
+  campaignFolderId: string | null;
+  statusMarkdown: string | null;
+  statusSensitiveMarkdown: string | null;
+}
+
+/** Only entities with a stored dossier — everything else has nothing to seed. */
+const HAS_DOSSIER = {
+  OR: [{ statusMarkdown: { not: null } }, { statusSensitiveMarkdown: { not: null } }],
+};
+
+// Explicit selects everywhere below: the seed only reads scope + dossier
+// columns, and a narrow select keeps the script runnable against a prod
+// copy that lags the freshest migrations.
+const ACCOUNT_SELECT = {
+  id: true,
+  name: true,
+  driveFolderId: true,
+  statusMarkdown: true,
+  statusSensitiveMarkdown: true,
+} as const;
+
+const CAMPAIGN_SELECT = {
+  id: true,
+  accountId: true,
+  name: true,
+  driveFolderId: true,
+  statusMarkdown: true,
+  statusSensitiveMarkdown: true,
+  account: { select: { name: true } },
+} as const;
+
+async function collectEntities(args: Args): Promise<SeedEntity[]> {
+  if (args.campaignId) {
+    const c = await prisma.campaign.findUnique({
+      where: { id: args.campaignId },
+      select: CAMPAIGN_SELECT,
+    });
+    if (!c) throw new Error(`No campaign with id ${args.campaignId}`);
+    return [
+      {
+        accountId: c.accountId,
+        accountName: c.account.name,
+        entityType: 'campaign',
+        entityId: c.id,
+        entityName: c.name,
+        campaignFolderId: c.driveFolderId,
+        statusMarkdown: c.statusMarkdown,
+        statusSensitiveMarkdown: c.statusSensitiveMarkdown,
+      },
+    ];
+  }
+
+  const accounts = await prisma.account.findMany({
+    where: args.accountId ? { id: args.accountId } : HAS_DOSSIER,
+    select: ACCOUNT_SELECT,
+    orderBy: { name: 'asc' },
+  });
+  if (args.accountId && accounts.length === 0) {
+    throw new Error(`No account with id ${args.accountId}`);
+  }
+  const campaigns = await prisma.campaign.findMany({
+    where: args.accountId ? { accountId: args.accountId, ...HAS_DOSSIER } : HAS_DOSSIER,
+    select: CAMPAIGN_SELECT,
+    orderBy: [{ accountId: 'asc' }, { name: 'asc' }],
+  });
+
+  return [
+    ...accounts.map((a): SeedEntity => ({
+      accountId: a.id,
+      accountName: a.name,
+      entityType: 'account',
+      entityId: a.id,
+      entityName: a.name,
+      campaignFolderId: a.driveFolderId,
+      statusMarkdown: a.statusMarkdown,
+      statusSensitiveMarkdown: a.statusSensitiveMarkdown,
+    })),
+    ...campaigns.map((c): SeedEntity => ({
+      accountId: c.accountId,
+      accountName: c.account.name,
+      entityType: 'campaign',
+      entityId: c.id,
+      entityName: c.name,
+      campaignFolderId: c.driveFolderId,
+      statusMarkdown: c.statusMarkdown,
+      statusSensitiveMarkdown: c.statusSensitiveMarkdown,
+    })),
+  ];
+}
+
+// ── Store access ─────────────────────────────────────────────────────────────
+
+/** Exact texts already ACTIVE in the container — the deterministic NOOP
+ *  filter. Embedding-status-independent on purpose: a row that lost (or
+ *  never got) its vector is invisible to D3 retrieval but still means "this
+ *  fact is seeded". */
+async function fetchActiveTexts(
+  entityType: 'account' | 'campaign',
+  entityId: string,
+): Promise<Set<string>> {
+  const rows = await prisma.$queryRaw<Array<{ text: string }>>`
+    SELECT text FROM insights
+    WHERE entity_type = ${entityType}
+      AND entity_id = ${entityId}::uuid
+      AND state = 'active'
+  `;
+  return new Set(rows.map((r) => r.text));
+}
+
+/**
+ * UUIDv7 — the store's id convention (@default(uuid(7)) in gub-schemas,
+ * generated client-side by Prisma, which raw SQL bypasses). Time-ordered
+ * ids keep seeded rows consistent with apply-path rows.
+ */
+function uuidv7(): string {
+  const bytes = crypto.randomBytes(16);
+  const ts = BigInt(Date.now());
+  for (let i = 0; i < 6; i++) {
+    bytes[i] = Number((ts >> BigInt(8 * (5 - i))) & 0xffn);
+  }
+  bytes[6] = (bytes[6]! & 0x0f) | 0x70;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+  const hex = bytes.toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+/**
+ * Apply ADD ops directly: insights row + insight_changes(ADD) audit row, one
+ * transaction per entity. Raw SQL because drive-sync's Prisma schema has no
+ * Insight models (D3 precedent) and `embedding` is Unsupported("vector")
+ * anyway. The column list stays valid on both the dev Appendix-A DDL and
+ * the canonical D1/D4 migrations: sync_run_id / op_hash are omitted (seed
+ * rows carry NULL), created_at/updated_at are explicit (canonical
+ * insights.updated_at has no DB default).
+ *
+ * Embedding failure aborts BEFORE any write — a seeded row without a vector
+ * would be invisible to D3 retrieval, and the deterministic NOOP filter
+ * makes a re-run after fixing credentials safe.
+ */
+async function applyAdds(adds: InsightOp[]): Promise<void> {
+  if (adds.length === 0) return;
+  const vectors = await embedTexts(adds.map((op) => op.candidate.text));
+  await prisma.$transaction(
+    async (tx) => {
+      for (const [i, op] of adds.entries()) {
+        const c: CandidateInsight = op.candidate;
+        const insightId = uuidv7();
+        const changeId = uuidv7();
+        const vec = `[${vectors[i]!.join(',')}]`;
+        // created_by_op is a plain uuid (no FK), so it can reference the
+        // change row inserted after it — same link the apply path writes.
+        await tx.$executeRaw`
+          INSERT INTO insights
+            (id, account_id, entity_type, entity_id, text, embedding, state,
+             created_by_op, created_at, updated_at)
+          VALUES
+            (${insightId}::uuid, ${c.accountId}::uuid, ${c.entityType},
+             ${c.entityId}::uuid, ${c.text}, ${vec}::vector, 'active',
+             ${changeId}::uuid, now(), now())
+        `;
+        await tx.$executeRaw`
+          INSERT INTO insight_changes
+            (id, insight_id, op, previous_text, new_text, source_file_ids,
+             confidence, created_by, created_at)
+          VALUES
+            (${changeId}::uuid, ${insightId}::uuid, 'ADD', NULL, ${c.text},
+             ${c.sourceFileIds}::text[], ${c.confidence},
+             ${DRIVE_SYNC_SYSTEM_STAFF_ID}::uuid, now())
+        `;
+      }
+    },
+    { timeout: 120_000 },
+  );
+}
+
+// ── Per-entity flow ──────────────────────────────────────────────────────────
+
+interface EntityCounts {
+  facts: number;
+  candidates: number;
+  /** Real run: ADDs applied. Dry run: candidates that would be seeded. */
+  seeded: number;
+  /** Exact text already ACTIVE in the container. */
+  noops: number;
+  /** Reconcile emitted a merge verb / NOOP — not applied by the seed. */
+  skipped: number;
+}
+
+async function processEntity(entity: SeedEntity, args: Args): Promise<EntityCounts> {
+  const label = `${entity.entityType} "${entity.entityName}"`;
+  const warn = (m: string): void => console.warn(`  ⚠ ${m}`);
+
+  const facts = dossierFacts({
+    statusMarkdown: entity.statusMarkdown,
+    statusSensitiveMarkdown: entity.statusSensitiveMarkdown,
+    asOfDate: args.asOfDate,
+    generalSourceId: dossierSourceId('status_markdown', entity.entityType, entity.entityId),
+    sensitiveSourceId: dossierSourceId(
+      'status_sensitive_markdown',
+      entity.entityType,
+      entity.entityId,
+    ),
+  });
+
+  const target: CandidateTarget = {
+    accountId: entity.accountId,
+    entityType: entity.entityType,
+    entityStatus: entity.entityType === 'account' ? 'account' : 'existing',
+    entityId: entity.entityId,
+    campaignFolderId: entity.campaignFolderId,
+    entityName: entity.entityName,
+  };
+  const candidates = toCandidateInsights(target, { field_changes: [], notes: facts }, warn);
+
+  const existing = await fetchActiveTexts(entity.entityType, entity.entityId);
+  const fresh = candidates.filter((c) => !existing.has(c.text));
+  const noops = candidates.length - fresh.length;
+
+  if (args.dryRun) {
+    for (const c of candidates) {
+      const status = existing.has(c.text) ? 'already-present' : 'would-seed';
+      console.log(`  [${status}] ${c.text}  ← ${c.sourceFileIds.join(', ')}`);
+    }
+    console.log(
+      `  ${label}: facts=${facts.length} candidates=${candidates.length} would-seed=${fresh.length} noop=${noops}`,
+    );
+    return {
+      facts: facts.length,
+      candidates: candidates.length,
+      seeded: fresh.length,
+      noops,
+      skipped: 0,
+    };
+  }
+
+  const ops = fresh.length > 0 ? await reconcileCandidates(fresh, { warn }) : [];
+  const adds = ops.filter((op) => op.op === 'ADD');
+  const skippedOps = ops.filter((op) => op.op !== 'ADD');
+  for (const op of skippedOps) {
+    console.log(
+      `  [skip ${op.op}] "${op.candidate.text.slice(0, 80)}" — ${op.reasoning} (the seed never mutates existing insights)`,
+    );
+  }
+
+  await applyAdds(adds);
+  console.log(
+    `  ${label}: facts=${facts.length} seeded=${adds.length} noop=${noops} skipped=${skippedOps.length}`,
+  );
+  return {
+    facts: facts.length,
+    candidates: candidates.length,
+    seeded: adds.length,
+    noops,
+    skipped: skippedOps.length,
+  };
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const entities = await collectEntities(args);
+  if (entities.length === 0) {
+    console.log('Nothing to seed — no entities with a stored dossier.');
+    return;
+  }
+
+  console.log(
+    `${args.dryRun ? 'DRY RUN (no writes) — ' : ''}seeding insight store from ${entities.length} dossier(s), transient cutoff ${args.asOfDate}`,
+  );
+
+  const byAccount = new Map<string, { name: string; counts: EntityCounts }>();
+  const failures: string[] = [];
+
+  for (const entity of entities) {
+    console.log(
+      `\n${entity.accountName} / ${entity.entityType} "${entity.entityName}" (${entity.entityId})`,
+    );
+    try {
+      const counts = await processEntity(entity, args);
+      const roll = byAccount.get(entity.accountId) ?? {
+        name: entity.accountName,
+        counts: { facts: 0, candidates: 0, seeded: 0, noops: 0, skipped: 0 },
+      };
+      roll.counts.facts += counts.facts;
+      roll.counts.candidates += counts.candidates;
+      roll.counts.seeded += counts.seeded;
+      roll.counts.noops += counts.noops;
+      roll.counts.skipped += counts.skipped;
+      byAccount.set(entity.accountId, roll);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`  ✗ failed: ${msg}`);
+      failures.push(`${entity.entityType} ${entity.entityId} ("${entity.entityName}"): ${msg}`);
+    }
+  }
+
+  console.log(`\nPer-account totals${args.dryRun ? ' (dry-run)' : ''}:`);
+  for (const { name, counts } of byAccount.values()) {
+    console.log(
+      `  ${name}: ${counts.seeded} insight(s) ${args.dryRun ? 'would be ' : ''}seeded / ${counts.noops} already present / ${counts.skipped} skipped (merge-verb) — ${counts.candidates} candidates from ${counts.facts} facts`,
+    );
+  }
+
+  if (failures.length > 0) {
+    throw new Error(
+      `${failures.length} entity(ies) failed — re-run is safe (idempotent):\n  ${failures.join('\n  ')}`,
+    );
+  }
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+    process.exit(0);
+  })
+  .catch(async (err) => {
+    console.error(err instanceof Error ? err.message : String(err));
+    await prisma.$disconnect().catch(() => {});
+    process.exit(1);
+  });

--- a/src/drive/__tests__/dossier-facts.test.ts
+++ b/src/drive/__tests__/dossier-facts.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+import {
+  dossierFacts,
+  dossierSourceId,
+  extractSrcMarkers,
+  splitDossierBullets,
+} from '../dossier-facts';
+
+const AS_OF = '2026-08-28';
+const GENERAL = 'status_markdown:campaign:camp_1';
+const SENSITIVE = 'status_sensitive_markdown:campaign:camp_1';
+
+/** The shape assembleStatusMarkdown produces (header + sections). */
+const FULL_DOSSIER = [
+  '_edited_at: 2026-08-20_',
+  '',
+  '## At a glance',
+  '- Status: live',
+  '- Budget: $200,000.00',
+  '',
+  '## Context',
+  '- The campaign creative concept is titled "Drive Further". [src: 1abc]',
+  '- Production is handled by the internal studio team. [src: 1def]',
+  '',
+  '## Transient',
+  '- Shoot window planned for late September. [expires: 2026-10-01] [src: 1ghi]',
+  '- Print deadline was last Friday. [expires: 2026-08-20] [src: 1jkl]',
+  '',
+].join('\n');
+
+describe('splitDossierBullets', () => {
+  it('splits bullet lines, stripping markers and whitespace', () => {
+    expect(splitDossierBullets('- one fact\n-  another fact  \n- third')).toEqual([
+      'one fact',
+      'another fact',
+      'third',
+    ]);
+  });
+
+  it('treats prose lines (no bullet marker) as one fact per line', () => {
+    expect(splitDossierBullets('First paragraph of prose.\n\nSecond paragraph.')).toEqual([
+      'First paragraph of prose.',
+      'Second paragraph.',
+    ]);
+  });
+
+  it('handles nested bullets and CRLF endings', () => {
+    expect(splitDossierBullets('- top\r\n  - nested detail')).toEqual(['top', 'nested detail']);
+  });
+
+  it('drops blank lines and sub-minimum debris', () => {
+    expect(splitDossierBullets('- ok fact\n-\n- …\n   \n- x')).toEqual(['ok fact']);
+  });
+
+  it('returns [] for null/empty bodies', () => {
+    expect(splitDossierBullets(null)).toEqual([]);
+    expect(splitDossierBullets('')).toEqual([]);
+  });
+});
+
+describe('extractSrcMarkers', () => {
+  it('hoists the trailing [src: ...] citation and strips it from the text', () => {
+    expect(extractSrcMarkers('CMO escalated over a budget overrun. [src: 1abc]')).toEqual({
+      text: 'CMO escalated over a budget overrun.',
+      fileIds: ['1abc'],
+    });
+  });
+
+  it('collects multiple markers and comma/space-separated ids, deduped', () => {
+    expect(extractSrcMarkers('Merged fact from two files. [src: 1abc, 1def] [src: 1abc]')).toEqual({
+      text: 'Merged fact from two files.',
+      fileIds: ['1abc', '1def'],
+    });
+  });
+
+  it('keeps [expires: ...] markers in the text', () => {
+    expect(
+      extractSrcMarkers('Kat polishing the fun fact. [expires: 2026-06-11] [src: 1abc]'),
+    ).toEqual({ text: 'Kat polishing the fun fact. [expires: 2026-06-11]', fileIds: ['1abc'] });
+  });
+
+  it('returns the line untouched when no marker is present', () => {
+    expect(extractSrcMarkers('Plain prose fact.')).toEqual({
+      text: 'Plain prose fact.',
+      fileIds: [],
+    });
+  });
+});
+
+describe('dossierSourceId', () => {
+  it('encodes tier, entity type and id', () => {
+    expect(dossierSourceId('status_markdown', 'account', 'a1')).toBe('status_markdown:account:a1');
+    expect(dossierSourceId('status_sensitive_markdown', 'campaign', 'c1')).toBe(
+      'status_sensitive_markdown:campaign:c1',
+    );
+  });
+});
+
+describe('dossierFacts', () => {
+  it('extracts Context and surviving Transient bullets with [src] provenance, never At a glance', () => {
+    const facts = dossierFacts({
+      statusMarkdown: FULL_DOSSIER,
+      statusSensitiveMarkdown: null,
+      asOfDate: AS_OF,
+      generalSourceId: GENERAL,
+      sensitiveSourceId: SENSITIVE,
+    });
+    expect(facts).toEqual([
+      {
+        text: 'The campaign creative concept is titled "Drive Further".',
+        source_file_ids: ['1abc'],
+      },
+      {
+        text: 'Production is handled by the internal studio team.',
+        source_file_ids: ['1def'],
+      },
+      {
+        text: 'Shoot window planned for late September. [expires: 2026-10-01]',
+        source_file_ids: ['1ghi'],
+      },
+    ]);
+  });
+
+  it('drops transient bullets expired before the as-of date', () => {
+    const facts = dossierFacts({
+      statusMarkdown: FULL_DOSSIER,
+      statusSensitiveMarkdown: null,
+      asOfDate: '2026-11-01',
+      generalSourceId: GENERAL,
+      sensitiveSourceId: SENSITIVE,
+    });
+    expect(facts.map((f) => f.text)).toEqual([
+      'The campaign creative concept is titled "Drive Further".',
+      'Production is handled by the internal studio team.',
+    ]);
+  });
+
+  it('keeps transient bullets without an expires marker (pruner posture)', () => {
+    const facts = dossierFacts({
+      statusMarkdown: '## Transient\n- No marker on this one. [src: 1abc]',
+      statusSensitiveMarkdown: null,
+      asOfDate: AS_OF,
+      generalSourceId: GENERAL,
+      sensitiveSourceId: SENSITIVE,
+    });
+    expect(facts.map((f) => f.text)).toEqual(['No marker on this one.']);
+  });
+
+  it('falls back to the tier sentinel for bullets without a [src] citation', () => {
+    const facts = dossierFacts({
+      statusMarkdown: '## Context\n- Prose-era fact without citation.',
+      statusSensitiveMarkdown: '## Context\n- Sensitive budget detail.',
+      asOfDate: AS_OF,
+      generalSourceId: GENERAL,
+      sensitiveSourceId: SENSITIVE,
+    });
+    expect(facts).toEqual([
+      { text: 'Prose-era fact without citation.', source_file_ids: [GENERAL] },
+      { text: 'Sensitive budget detail.', source_file_ids: [SENSITIVE] },
+    ]);
+  });
+
+  it('dedupes identical texts across sections and tiers, first (general) wins', () => {
+    const facts = dossierFacts({
+      statusMarkdown:
+        '## Context\n- Shared fact. [src: 1abc]\n\n## Transient\n- Shared fact. [src: 1def]',
+      statusSensitiveMarkdown: '## Context\n- Shared fact.\n- Only sensitive.',
+      asOfDate: AS_OF,
+      generalSourceId: GENERAL,
+      sensitiveSourceId: SENSITIVE,
+    });
+    expect(facts).toEqual([
+      { text: 'Shared fact.', source_file_ids: ['1abc'] },
+      { text: 'Only sensitive.', source_file_ids: [SENSITIVE] },
+    ]);
+  });
+
+  it('drops bullets whose text is only a citation', () => {
+    const facts = dossierFacts({
+      statusMarkdown: '## Context\n- [src: 1abc]\n- Real fact. [src: 1def]',
+      statusSensitiveMarkdown: null,
+      asOfDate: AS_OF,
+      generalSourceId: GENERAL,
+      sensitiveSourceId: SENSITIVE,
+    });
+    expect(facts.map((f) => f.text)).toEqual(['Real fact.']);
+  });
+
+  it('returns [] for null dossiers and dossiers without Context/Transient', () => {
+    expect(
+      dossierFacts({
+        statusMarkdown: null,
+        statusSensitiveMarkdown: null,
+        asOfDate: AS_OF,
+        generalSourceId: GENERAL,
+        sensitiveSourceId: SENSITIVE,
+      }),
+    ).toEqual([]);
+    expect(
+      dossierFacts({
+        statusMarkdown: '_edited_at: 2026-08-20_\n\n## At a glance\n- Status: live\n',
+        statusSensitiveMarkdown: null,
+        asOfDate: AS_OF,
+        generalSourceId: GENERAL,
+        sensitiveSourceId: SENSITIVE,
+      }),
+    ).toEqual([]);
+  });
+});

--- a/src/drive/dossier-facts.ts
+++ b/src/drive/dossier-facts.ts
@@ -1,0 +1,130 @@
+// D5 (#41): split a stored status_markdown dossier into the discrete facts
+// the insight-store seed backfills from. Pure text processing over the
+// dossier monolith (the shape status-synthesis.ts assembles): the
+// `## Context` body plus the surviving `## Transient` bullets, for each of
+// the general/sensitive column pair. `## At a glance` is deliberately NOT
+// parsed — it's a code render of structured entity fields (D11), so seeding
+// it would duplicate row data as prose insights.
+//
+// NO prisma, NO ai imports — orchestration (store diff, reconcile, apply)
+// lives in scripts/seed-insights.ts; this module stays hermetically
+// testable, per the D2 candidate-insight precedent.
+
+import type { DistilledNote } from './candidate-insight';
+import {
+  extractContextSection,
+  extractTransientSection,
+  pruneExpiredTransientBullets,
+} from './status-synthesis';
+
+/**
+ * Floor for a parsed line to count as a fact — drops stray bullet markers,
+ * lone punctuation, and blank-ish debris without judging real content.
+ */
+export const MIN_FACT_LENGTH = 3;
+
+/** Dossier tier a seeded fact's provenance sentinel names. */
+export type DossierTier = 'status_markdown' | 'status_sensitive_markdown';
+
+/**
+ * FALLBACK provenance for a bullet without a `[src: ...]` citation (old
+ * prose-era dossiers). The dossier is a DB column, not a Drive file, so the
+ * "source file id" is a stable non-Drive ref — the same pattern as the
+ * scan's `piece:<id>` rollup source ids. Carrying the tier keeps
+ * sensitive-sourced facts identifiable (the insight schema has no
+ * sensitivity flag today; a later sensitivity backfill can key off this).
+ */
+export function dossierSourceId(
+  tier: DossierTier,
+  entityType: 'account' | 'campaign',
+  entityId: string,
+): string {
+  return `${tier}:${entityType}:${entityId}`;
+}
+
+/**
+ * Every synthesized bullet ends with a `[src: <fileId>]` citation (the
+ * status-synthesis output contract; merged bullets can carry several).
+ * That's the fact's REAL Drive provenance — hoist it into structured
+ * sourceFileIds like every live candidate, and strip the marker from the
+ * fact text so embeddings and reconciliation compare facts, not citation
+ * tails. `[expires: ...]` markers are deliberately KEPT in the text — the
+ * store has no expiry mechanics, so the shelf-life is part of the fact.
+ */
+const SRC_MARKER_RE = /\s*\[src:\s*([^\]]+)\]/g;
+
+export function extractSrcMarkers(line: string): { text: string; fileIds: string[] } {
+  const fileIds: string[] = [];
+  const text = line
+    .replace(SRC_MARKER_RE, (_match, ids: string) => {
+      for (const id of ids.split(/[\s,]+/)) {
+        if (id.length > 0 && !fileIds.includes(id)) fileIds.push(id);
+      }
+      return '';
+    })
+    .trim();
+  return { text, fileIds };
+}
+
+/**
+ * Section body → one fact per line. Context/Transient bodies are
+ * code-assembled bullet text (one `- bullet` per line, per the synthesis
+ * contract), but older dossiers may hold prose — a line-based split handles
+ * both: the bullet marker is stripped when present, and any non-empty line
+ * stands as one fact. Never seed the whole blob as one insight (pitfall 3).
+ */
+export function splitDossierBullets(body: string | null): string[] {
+  if (!body) return [];
+  return body
+    .split(/\r?\n/)
+    .map((line) => line.replace(/^\s*-\s?/, '').trim())
+    .filter((text) => text.length >= MIN_FACT_LENGTH);
+}
+
+export interface DossierFactsArgs {
+  statusMarkdown: string | null;
+  statusSensitiveMarkdown: string | null;
+  /** Scan day (YYYY-MM-DD) — transient bullets expiring before it are dropped. */
+  asOfDate: string;
+  generalSourceId: string;
+  sensitiveSourceId: string;
+}
+
+/**
+ * Parse one entity's dossier pair into discrete seed facts, shaped as
+ * DistilledNotes so toCandidateInsights consumes them unchanged.
+ *
+ * - Expired transient bullets are dropped BEFORE splitting (D23 posture:
+ *   the seed never resurrects what synthesis would prune).
+ * - `[src: ...]` citations become the note's source_file_ids; a bullet
+ *   without one falls back to the tier's dossier sentinel, so provenance
+ *   is never empty (A1).
+ * - Facts are deduped by exact (post-strip) text across sections AND
+ *   tiers — two identical candidates in one run would otherwise both
+ *   reconcile against a store that contains neither, and both would ADD.
+ *   First occurrence wins, so a fact present in both tiers keeps the
+ *   general provenance.
+ */
+export function dossierFacts(args: DossierFactsArgs): DistilledNote[] {
+  const facts: DistilledNote[] = [];
+  const seen = new Set<string>();
+
+  const collect = (stored: string | null, fallbackSourceId: string): void => {
+    if (!stored) return;
+    const context = extractContextSection(stored);
+    const transient = pruneExpiredTransientBullets(extractTransientSection(stored), args.asOfDate);
+    for (const line of [...splitDossierBullets(context), ...splitDossierBullets(transient)]) {
+      const { text, fileIds } = extractSrcMarkers(line);
+      if (text.length < MIN_FACT_LENGTH || seen.has(text)) continue;
+      seen.add(text);
+      facts.push({
+        text,
+        source_file_ids: fileIds.length > 0 ? fileIds : [fallbackSourceId],
+      });
+    }
+  };
+
+  collect(args.statusMarkdown, args.generalSourceId);
+  collect(args.statusSensitiveMarkdown, args.sensitiveSourceId);
+  return facts;
+}


### PR DESCRIPTION
Closes #41. Stacked on #54 (D4 emit) — merge that first.

One-shot, idempotent backfill: distills each entity's `status_markdown` dossier
(+ sensitive companion) into discrete facts and seeds them as initial insights,
so the pipeline doesn't re-derive years of context on the first live scan.

## What's here

- **`scripts/seed-insights.ts`** + `npm run seed:insights` — mirrors the seed-script
  template (arg parsing, entity validation before writing, `main().then/.catch` footer).
  Flags: `--account-id` (seeds the account **and** all its campaigns), `--campaign-id`,
  `--all`, `--dry-run`, `--as-of <YYYY-MM-DD>` (transient-expiry cutoff, default today).
- **`src/drive/dossier-facts.ts`** — pure dossier→facts parsing (hermetic, D2-style),
  reusing `extractContextSection` / `extractTransientSection` /
  `pruneExpiredTransientBullets`. One fact per bullet; `## At a glance` is never
  seeded (it's a code render of structured fields). Facts flow through the existing
  `toCandidateInsights` → `reconcileCandidates` → ADD-apply chain.

## Design decisions

- **Direct write, not the review gate** (spec §3): a whole-dossier backfill would
  flood the reviewer with hundreds of cards. Writes `insights` +
  `insight_changes(op:'ADD', created_by = DRIVE_SYNC_SYSTEM_STAFF_ID)` in one
  transaction per entity, so `replay(insight_changes) == snapshot(insights)` (D6)
  holds over seeded rows. Seed rows carry `sync_run_id = NULL` / `op_hash = NULL`
  (no run, no proposal — exactly the case the schema comment anticipates; the
  UNIQUE key never collides on NULLs).
- **Deterministic idempotency**: before reconciling, any candidate whose exact text
  is already an ACTIVE insight in its container is dropped as NOOP. A re-run over
  an unchanged dossier is all-NOOP with **zero Gemini calls**. Only near-duplicates
  (a store that drifted via live scans) reach embed → retrieve → LLM reconcile, and
  of those ops **only ADDs are applied** — the seed never mutates existing insights
  (UPDATE/SUPERSEDE are logged and skipped; live reconciliation owns merges).
- **Provenance is real, not a sentinel**: every synthesized bullet carries a
  `[src: <fileId>]` citation (synthesis output contract) — hoisted into
  `sourceFileIds` and stripped from the fact text so embeddings compare facts,
  not citation tails. Markerless (prose-era) bullets fall back to a
  `status_markdown:<type>:<id>` sentinel, so provenance is never empty (A1).
  `[expires:]` markers stay in the text. Sensitive-tier facts are seeded (spec
  pitfall 4 decision).
- **Raw SQL apply** (D3 precedent — no Insight models in this repo's Prisma
  schema): the column list works on both the dev Appendix-A DDL and the canonical
  D1/D4 migrations; `created_at`/`updated_at` are explicit (canonical
  `insights.updated_at` has no DB default); ids are uuidv7 to match the store
  convention. Embedding failure aborts before any write.
- `--reviewer-staff-id` from the spec's arg sketch is dropped — with the
  direct-write ruling there is no reviewer in the loop.
- Pieces (`campaign_pieces.status_markdown`) are out of scope: piece/idea insights
  are the idea-extraction tier (D2 ruling) and the candidate contract is
  account|campaign only.

## Acceptance (verified on a prod copy, 48 dossiers / 951 facts)

- [x] `--dry-run` lists zod-validated, scoped candidates with provenance
- [x] Real run seeds: 945 insights across 48 containers (212 account / 733 campaign)
- [x] Re-run yields an identical store — converged run reports
      `0 seeded / 945 already present`, zero new rows (verified by count, not eyeball)
- [x] Per-account counts logged (`N seeded / M already present / K skipped`)
- [x] `replay(insight_changes) == snapshot(insights)`: 945 = 945 = 945; every change
      row replays to its snapshot; 0 orphans, 0 NULL embeddings, 0 scope mismatches

Run once per environment before enabling `INSIGHT_RECONCILE=propose`.

`tsc --noEmit` clean, 87/87 tests green (12 new), eslint/prettier clean.
