### PR TITLE
feat(drive): point-in-time insight queries — insightsAsOf replay over insight_changes (D6 #42)

### DIFF
--- a/src/drive/__tests__/insight-asof.test.ts
+++ b/src/drive/__tests__/insight-asof.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Hermetic suite for insight-asof.ts (D6 #42).
+ *
+ * The op-log is synthetic: a hand-built add → update → update → supersede
+ * timeline whose active set at every cutoff is hand-derived, replayed
+ * through the injected `loadChanges` seam (a fake that filters + orders
+ * exactly like the SQL loader). No prisma, no network. The module boundary
+ * mocks below only neutralize import-time side effects.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../config', () => ({ config: {} }));
+vi.mock('../../logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock('../../prisma', () => ({ prisma: {} }));
+
+import {
+  insightsAsOf,
+  replayInsightChanges,
+  type AsOfInsight,
+  type InsightChangeRow,
+  type loadInsightChanges,
+} from '../insight-asof';
+
+const CAMPAIGN_ID = 'bbbbbbbb-0000-4000-8000-000000000002';
+
+// uuidv7-shaped ids, crafted so lexicographic order == mint order.
+const INSIGHT_A = '01000000-0000-7000-8000-00000000000a';
+const INSIGHT_B = '02000000-0000-7000-8000-00000000000b';
+const INSIGHT_C = '03000000-0000-7000-8000-00000000000c';
+
+const T1 = new Date('2026-06-01T00:00:00.000Z'); // ADD A
+const T2 = new Date('2026-06-10T00:00:00.000Z'); // ADD B
+const T3 = new Date('2026-07-01T00:00:00.000Z'); // UPDATE A (first)
+const T4 = new Date('2026-07-05T00:00:00.000Z'); // UPDATE A (second)
+const T5 = new Date('2026-07-15T00:00:00.000Z'); // SUPERSEDE A → C
+const T6 = new Date('2026-08-01T00:00:00.000Z'); // UPDATE B
+const NOW = new Date('2026-08-28T12:00:00.000Z');
+
+const A_TEXT_V1 = 'Launch is planned for May.';
+const A_TEXT_V2 = 'Launch shifted from May to June 1.';
+const A_TEXT_V3 = 'Launch shifted again to June 3.';
+const B_TEXT_V1 = 'Budget is $50k.';
+const B_TEXT_V2 = 'Budget raised to $75k.';
+const C_TEXT = 'Launch happened June 3; the campaign is live.';
+
+function row(
+  over: Partial<InsightChangeRow> &
+    Pick<InsightChangeRow, 'changeId' | 'insightId' | 'op' | 'createdAt'>,
+): InsightChangeRow {
+  return { newText: null, replacementId: null, ...over };
+}
+
+/** The synthetic op-log, deliberately NOT in chronological array order —
+ * the fake loader must impose the SQL's (created_at, id) ordering. */
+const OP_LOG: InsightChangeRow[] = [
+  row({
+    changeId: 'c6000000-0000-7000-8000-000000000006',
+    insightId: INSIGHT_B,
+    op: 'UPDATE',
+    newText: B_TEXT_V2,
+    createdAt: T6,
+  }),
+  row({
+    changeId: 'c1000000-0000-7000-8000-000000000001',
+    insightId: INSIGHT_A,
+    op: 'ADD',
+    newText: A_TEXT_V1,
+    createdAt: T1,
+  }),
+  row({
+    changeId: 'c5000000-0000-7000-8000-000000000005',
+    insightId: INSIGHT_A,
+    op: 'SUPERSEDE',
+    newText: C_TEXT,
+    replacementId: INSIGHT_C,
+    createdAt: T5,
+  }),
+  row({
+    changeId: 'c3000000-0000-7000-8000-000000000003',
+    insightId: INSIGHT_A,
+    op: 'UPDATE',
+    newText: A_TEXT_V2,
+    createdAt: T3,
+  }),
+  row({
+    changeId: 'c2000000-0000-7000-8000-000000000002',
+    insightId: INSIGHT_B,
+    op: 'ADD',
+    newText: B_TEXT_V1,
+    createdAt: T2,
+  }),
+  row({
+    changeId: 'c4000000-0000-7000-8000-000000000004',
+    insightId: INSIGHT_A,
+    op: 'UPDATE',
+    newText: A_TEXT_V3,
+    createdAt: T4,
+  }),
+];
+
+/** Filters + orders like loadInsightChanges' SQL: created_at <= at,
+ * ORDER BY created_at ASC, id ASC. */
+function fakeLoader(log: InsightChangeRow[]): typeof loadInsightChanges {
+  return async (_scope, at) =>
+    log
+      .filter((r) => r.createdAt.getTime() <= at.getTime())
+      .sort(
+        (a, b) =>
+          a.createdAt.getTime() - b.createdAt.getTime() ||
+          (a.changeId < b.changeId ? -1 : a.changeId > b.changeId ? 1 : 0),
+      );
+}
+
+function asOf(at: Date, log: InsightChangeRow[] = OP_LOG): Promise<AsOfInsight[]> {
+  return insightsAsOf('campaign', CAMPAIGN_ID, at, { loadChanges: fakeLoader(log) });
+}
+
+function texts(set: AsOfInsight[]): Record<string, string> {
+  return Object.fromEntries(set.map((i) => [i.id, i.text]));
+}
+
+describe('insightsAsOf — replay at historical dates', () => {
+  it('returns the empty set before any op', async () => {
+    expect(await asOf(new Date('2026-05-01T00:00:00.000Z'))).toEqual([]);
+  });
+
+  it('cutoff is inclusive: replay AT the first ADD sees it', async () => {
+    expect(texts(await asOf(T1))).toEqual({ [INSIGHT_A]: A_TEXT_V1 });
+  });
+
+  it('date 1 — after both ADDs: original texts', async () => {
+    expect(texts(await asOf(new Date('2026-06-15T00:00:00.000Z')))).toEqual({
+      [INSIGHT_A]: A_TEXT_V1,
+      [INSIGHT_B]: B_TEXT_V1,
+    });
+  });
+
+  it('date 2 — between the two UPDATEs: lands on the intermediate text, not the latest', async () => {
+    expect(texts(await asOf(new Date('2026-07-03T00:00:00.000Z')))).toEqual({
+      [INSIGHT_A]: A_TEXT_V2,
+      [INSIGHT_B]: B_TEXT_V1,
+    });
+  });
+
+  it('date 3 — after the SUPERSEDE: target gone, replacement active, B untouched', async () => {
+    expect(texts(await asOf(new Date('2026-07-20T00:00:00.000Z')))).toEqual({
+      [INSIGHT_C]: C_TEXT,
+      [INSIGHT_B]: B_TEXT_V1,
+    });
+  });
+
+  it('SUPERSEDE applies atomically: at exactly its timestamp the set holds the replacement, never a hole', async () => {
+    const set = await asOf(T5);
+    expect(texts(set)).toEqual({ [INSIGHT_C]: C_TEXT, [INSIGHT_B]: B_TEXT_V1 });
+    expect(set).toHaveLength(2);
+  });
+
+  it('insightsAsOf(now) equals the current active snapshot (D4 invariant, generalized)', async () => {
+    // Hand-declared current snapshot: what insights(state='active') holds
+    // after the full timeline — C (A's replacement) + B at its latest text.
+    const snapshot: Record<string, string> = {
+      [INSIGHT_B]: B_TEXT_V2,
+      [INSIGHT_C]: C_TEXT,
+    };
+    expect(texts(await asOf(NOW))).toEqual(snapshot);
+  });
+
+  it('returns rows sorted by id and stamps lastChangeAt with the last touching op', async () => {
+    const set = await asOf(NOW);
+    expect(set.map((i) => i.id)).toEqual([INSIGHT_B, INSIGHT_C]);
+    expect(set.find((i) => i.id === INSIGHT_B)?.lastChangeAt).toEqual(T6);
+    expect(set.find((i) => i.id === INSIGHT_C)?.lastChangeAt).toEqual(T5);
+  });
+
+  it('passes the entity scope through to the loader', async () => {
+    const load = vi.fn(fakeLoader([]));
+    await insightsAsOf('account', CAMPAIGN_ID, NOW, { loadChanges: load });
+    expect(load).toHaveBeenCalledWith({ entityType: 'account', entityId: CAMPAIGN_ID }, NOW);
+  });
+
+  it('rejects an invalid Date', async () => {
+    await expect(asOf(new Date('nonsense'))).rejects.toThrow('invalid Date');
+  });
+
+  it('rejects a non-uuid entityId before any SQL runs', async () => {
+    const load = vi.fn(fakeLoader(OP_LOG));
+    await expect(
+      insightsAsOf('campaign', 'drive-folder-ref-123', NOW, { loadChanges: load }),
+    ).rejects.toThrow('not a uuid');
+    expect(load).not.toHaveBeenCalled();
+  });
+});
+
+describe('insightsAsOf — same-timestamp ties', () => {
+  it('orders same-created_at rows by id (deterministic replay)', async () => {
+    const ts = new Date('2026-06-20T00:00:00.000Z');
+    // Same timestamp; the UPDATE's change id sorts after the ADD's, so the
+    // fold must apply ADD first regardless of array order.
+    const log = [
+      row({
+        changeId: 'aa000000-0000-7000-8000-000000000002',
+        insightId: INSIGHT_A,
+        op: 'UPDATE',
+        newText: 'updated',
+        createdAt: ts,
+      }),
+      row({
+        changeId: 'aa000000-0000-7000-8000-000000000001',
+        insightId: INSIGHT_A,
+        op: 'ADD',
+        newText: 'added',
+        createdAt: ts,
+      }),
+    ];
+    const warn = vi.fn();
+    const set = await insightsAsOf('campaign', CAMPAIGN_ID, NOW, {
+      loadChanges: fakeLoader(log),
+      warn,
+    });
+    expect(texts(set)).toEqual({ [INSIGHT_A]: 'updated' });
+    expect(warn).not.toHaveBeenCalled(); // ADD folded before UPDATE — no upsert warning
+  });
+});
+
+describe('replayInsightChanges — fold degradation', () => {
+  const at = new Date('2026-06-01T00:00:00.000Z');
+
+  it('NOOP rows change nothing, whether present or absent', () => {
+    const noop = row({
+      changeId: 'dd000000-0000-7000-8000-0000000000dd',
+      insightId: INSIGHT_A,
+      op: 'NOOP',
+      createdAt: at,
+    });
+    const base = [
+      row({
+        changeId: 'aa000000-0000-7000-8000-0000000000aa',
+        insightId: INSIGHT_A,
+        op: 'ADD',
+        newText: 'fact',
+        createdAt: at,
+      }),
+    ];
+    expect(replayInsightChanges([...base, noop])).toEqual(replayInsightChanges(base));
+  });
+
+  it('warns on an unknown op and ignores it', () => {
+    const warn = vi.fn();
+    const set = replayInsightChanges(
+      [
+        row({
+          changeId: 'ee000000-0000-7000-8000-0000000000ee',
+          insightId: INSIGHT_A,
+          op: 'MERGE',
+          newText: 'x',
+          createdAt: at,
+        }),
+      ],
+      { warn },
+    );
+    expect(set).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('unknown op "MERGE"'));
+  });
+
+  it('UPDATE on an insight missing from the active set warns and upserts', () => {
+    const warn = vi.fn();
+    const set = replayInsightChanges(
+      [
+        row({
+          changeId: 'ee000000-0000-7000-8000-0000000000ee',
+          insightId: INSIGHT_A,
+          op: 'UPDATE',
+          newText: 'orphan update',
+          createdAt: at,
+        }),
+      ],
+      { warn },
+    );
+    expect(texts(set)).toEqual({ [INSIGHT_A]: 'orphan update' });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('not in the replayed active set'));
+  });
+
+  it('ADD without new_text warns and materializes nothing', () => {
+    const warn = vi.fn();
+    const set = replayInsightChanges(
+      [
+        row({
+          changeId: 'ee000000-0000-7000-8000-0000000000ee',
+          insightId: INSIGHT_A,
+          op: 'ADD',
+          createdAt: at,
+        }),
+      ],
+      { warn },
+    );
+    expect(set).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('no new_text'));
+  });
+
+  it('re-ADD of an active insight warns and replaces the text', () => {
+    const warn = vi.fn();
+    const set = replayInsightChanges(
+      [
+        row({
+          changeId: 'aa000000-0000-7000-8000-000000000001',
+          insightId: INSIGHT_A,
+          op: 'ADD',
+          newText: 'first',
+          createdAt: at,
+        }),
+        row({
+          changeId: 'aa000000-0000-7000-8000-000000000002',
+          insightId: INSIGHT_A,
+          op: 'ADD',
+          newText: 'second',
+          createdAt: at,
+        }),
+      ],
+      { warn },
+    );
+    expect(texts(set)).toEqual({ [INSIGHT_A]: 'second' });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('re-adds active insight'));
+  });
+
+  it('SUPERSEDE with a missing replacement link warns and still drops the target', () => {
+    const warn = vi.fn();
+    const set = replayInsightChanges(
+      [
+        row({
+          changeId: 'aa000000-0000-7000-8000-000000000001',
+          insightId: INSIGHT_A,
+          op: 'ADD',
+          newText: 'fact',
+          createdAt: at,
+        }),
+        row({
+          changeId: 'aa000000-0000-7000-8000-000000000002',
+          insightId: INSIGHT_A,
+          op: 'SUPERSEDE',
+          newText: 'replacement text',
+          createdAt: at,
+        }),
+      ],
+      { warn },
+    );
+    expect(set).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('created_by_op link missing'));
+  });
+
+  it('SUPERSEDE of an insight missing from the active set warns but still adds the replacement', () => {
+    const warn = vi.fn();
+    const set = replayInsightChanges(
+      [
+        row({
+          changeId: 'aa000000-0000-7000-8000-000000000001',
+          insightId: INSIGHT_A,
+          op: 'SUPERSEDE',
+          newText: 'replacement text',
+          replacementId: INSIGHT_C,
+          createdAt: at,
+        }),
+      ],
+      { warn },
+    );
+    expect(texts(set)).toEqual({ [INSIGHT_C]: 'replacement text' });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('not in the replayed active set'));
+  });
+
+  it('is deterministic: replaying the same slice twice yields identical output', () => {
+    const ordered = [...OP_LOG].sort(
+      (a, b) =>
+        a.createdAt.getTime() - b.createdAt.getTime() ||
+        (a.changeId < b.changeId ? -1 : a.changeId > b.changeId ? 1 : 0),
+    );
+    expect(replayInsightChanges(ordered)).toEqual(replayInsightChanges(ordered));
+  });
+});

--- a/src/drive/insight-asof.ts
+++ b/src/drive/insight-asof.ts
@@ -1,0 +1,249 @@
+/**
+ * insight-asof.ts — D6 (#42): point-in-time insight queries.
+ *
+ * `insightsAsOf(entityType, entityId, at)` reconstructs the ACTIVE insight
+ * set for an entity as of any past instant by replaying its append-only
+ * `insight_changes` op-log up to the cutoff — the "current state = fold of
+ * the change rows" pattern of the `*_changes` family (idea_changes et al.),
+ * generalized from D4's now-invariant `replay(insight_changes) ==
+ * snapshot(insights)` to an arbitrary `at`.
+ *
+ * Grounded in what the writers actually persist (GUB drive.review.ts apply,
+ * D5 seed):
+ *   - ADD    → change row's insight_id IS the new insight; new_text = text.
+ *   - UPDATE → insight_id is the edited insight; new_text = its new text.
+ *   - SUPERSEDE → ONE change row: insight_id = the dropped target, new_text
+ *     = the replacement's text. There is no paired ADD row — the replacement
+ *     insights row is minted in the same transaction and linked back via
+ *     insights.created_by_op = change.id. The loader recovers the
+ *     replacement id through that link, so a single fold step drops the
+ *     target AND adds the replacement atomically (the active set is never
+ *     transiently empty at any cutoff).
+ *   - NOOP   → no state change (not written today — propose.ts filters
+ *     NOOPs before they become cards — but the fold tolerates them).
+ *
+ * Ordering: strictly by created_at (timestamptz, tz-aware cutoff), ties
+ * broken by id — ids are uuidv7 on every write path, so the tie-break is
+ * itself time-ordered and deterministic across replays.
+ *
+ * Store access is prisma.$queryRaw like the rest of the insight tier (D3
+ * precedent): drive-sync's Prisma schema has no Insight models until the
+ * schema-package adoption lands. Read-only — this module never writes.
+ */
+
+import { prisma } from '../prisma';
+import { logger } from '../logger';
+import type { RetrievalScope } from './insight-reconcile';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** One op-log row, as the fold consumes it (already scoped + ordered). */
+export interface InsightChangeRow {
+  /** insight_changes.id — for warnings and the SUPERSEDE replacement link. */
+  changeId: string;
+  /** The insight the op targets (for SUPERSEDE: the DROPPED insight). */
+  insightId: string;
+  /** 'ADD' | 'UPDATE' | 'SUPERSEDE' | 'NOOP' — string to tolerate unknowns. */
+  op: string;
+  /** Text after the op; for SUPERSEDE this is the REPLACEMENT's text. */
+  newText: string | null;
+  createdAt: Date;
+  /** SUPERSEDE only: the replacement insight minted in the op's transaction
+   * (insights.created_by_op = this change's id); null when the link is
+   * missing (corrupt/foreign data — the fold warns and still drops). */
+  replacementId: string | null;
+}
+
+/** An insight active at the requested cutoff. */
+export interface AsOfInsight {
+  id: string;
+  text: string;
+  /** created_at of the last op-log row that touched this insight ≤ cutoff. */
+  lastChangeAt: Date;
+}
+
+/**
+ * The entity's op-log rows with created_at <= at, oldest first, ties broken
+ * by id. Scope is resolved by joining through insights (the change rows
+ * carry no entity columns); a SUPERSEDE's replacement — created in the same
+ * entity by the apply transaction — is reached via its own later rows'
+ * insight_id, so the join covers the whole per-entity history.
+ */
+export async function loadInsightChanges(
+  scope: RetrievalScope,
+  at: Date,
+): Promise<InsightChangeRow[]> {
+  const rows = await prisma.$queryRaw<
+    Array<{
+      change_id: string;
+      insight_id: string;
+      op: string;
+      new_text: string | null;
+      created_at: Date;
+      replacement_id: string | null;
+    }>
+  >`
+    SELECT ic.id::text         AS change_id,
+           ic.insight_id::text AS insight_id,
+           ic.op,
+           ic.new_text,
+           ic.created_at,
+           repl.id::text       AS replacement_id
+    FROM insight_changes ic
+    JOIN insights i ON i.id = ic.insight_id
+    LEFT JOIN insights repl
+      ON ic.op = 'SUPERSEDE'
+     AND repl.created_by_op = ic.id
+     AND repl.id <> ic.insight_id
+    WHERE i.entity_type = ${scope.entityType}
+      AND i.entity_id = ${scope.entityId}::uuid
+      AND ic.created_at <= ${at}
+    ORDER BY ic.created_at ASC, ic.id ASC
+  `;
+  return rows.map((r) => ({
+    changeId: r.change_id,
+    insightId: r.insight_id,
+    op: r.op,
+    newText: r.new_text,
+    createdAt: r.created_at,
+    replacementId: r.replacement_id,
+  }));
+}
+
+/**
+ * The entity's CURRENT active snapshot rows — the right-hand side of the
+ * D4 invariant `insightsAsOf(e, now) == snapshot`. For eval/verification
+ * (and D7's read path); the replay itself never consults it.
+ */
+export async function snapshotActiveInsights(scope: RetrievalScope): Promise<AsOfInsight[]> {
+  const rows = await prisma.$queryRaw<Array<{ id: string; text: string; updated_at: Date }>>`
+    SELECT id::text AS id, text, updated_at
+    FROM insights
+    WHERE entity_type = ${scope.entityType}
+      AND entity_id = ${scope.entityId}::uuid
+      AND state = 'active'
+    ORDER BY id ASC
+  `;
+  return rows.map((r) => ({ id: r.id, text: r.text, lastChangeAt: r.updated_at }));
+}
+
+export interface ReplayOptions {
+  warn?: (message: string) => void;
+}
+
+/**
+ * Pure fold over an ordered, pre-filtered op-log slice. Exported for the
+ * hermetic suite; insightsAsOf is the loader-wired entry point.
+ *
+ * Malformed rows degrade softly with a warn — the log is append-only and a
+ * historical query must not throw on one bad row years later:
+ *   - UPDATE on an insight not in the active set upserts it (its ADD row is
+ *     missing/foreign; the text is better preserved than dropped).
+ *   - ADD/UPDATE without new_text is skipped (nothing to materialize).
+ *   - SUPERSEDE always drops its target; the replacement is added only when
+ *     both the created_by_op link and new_text exist.
+ */
+export function replayInsightChanges(
+  rows: InsightChangeRow[],
+  opts: ReplayOptions = {},
+): AsOfInsight[] {
+  const warn = opts.warn ?? ((m: string): void => logger.warn(`[insight-asof] ${m}`));
+  const active = new Map<string, AsOfInsight>();
+
+  for (const row of rows) {
+    switch (row.op) {
+      case 'ADD': {
+        if (row.newText === null) {
+          warn(`ADD ${row.changeId} carries no new_text — skipping`);
+          break;
+        }
+        if (active.has(row.insightId)) {
+          warn(`ADD ${row.changeId} re-adds active insight ${row.insightId} — replacing text`);
+        }
+        active.set(row.insightId, {
+          id: row.insightId,
+          text: row.newText,
+          lastChangeAt: row.createdAt,
+        });
+        break;
+      }
+      case 'UPDATE': {
+        if (row.newText === null) {
+          warn(`UPDATE ${row.changeId} carries no new_text — skipping`);
+          break;
+        }
+        if (!active.has(row.insightId)) {
+          warn(
+            `UPDATE ${row.changeId} targets insight ${row.insightId} not in the replayed active set — upserting`,
+          );
+        }
+        active.set(row.insightId, {
+          id: row.insightId,
+          text: row.newText,
+          lastChangeAt: row.createdAt,
+        });
+        break;
+      }
+      case 'SUPERSEDE': {
+        // One row = drop target + add replacement, a single fold step — the
+        // apply writes both in one transaction, so no cutoff can observe the
+        // drop without the replacement.
+        if (!active.delete(row.insightId)) {
+          warn(
+            `SUPERSEDE ${row.changeId} targets insight ${row.insightId} not in the replayed active set`,
+          );
+        }
+        if (row.replacementId === null) {
+          warn(
+            `SUPERSEDE ${row.changeId} has no replacement insight (created_by_op link missing) — target dropped without replacement`,
+          );
+          break;
+        }
+        if (row.newText === null) {
+          warn(`SUPERSEDE ${row.changeId} carries no new_text — replacement skipped`);
+          break;
+        }
+        active.set(row.replacementId, {
+          id: row.replacementId,
+          text: row.newText,
+          lastChangeAt: row.createdAt,
+        });
+        break;
+      }
+      case 'NOOP':
+        break;
+      default:
+        warn(`unknown op "${row.op}" on change ${row.changeId} — ignoring`);
+    }
+  }
+
+  // uuidv7 ids: lexicographic == chronological, so this reads oldest-first.
+  return [...active.values()].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+}
+
+/** Injectable seam so the hermetic suite never touches prisma (D3 precedent). */
+export interface AsOfOptions extends ReplayOptions {
+  loadChanges?: typeof loadInsightChanges;
+}
+
+/**
+ * The entity's active insight set as of `at` (inclusive, tz-aware — the
+ * cutoff compares against timestamptz in UTC). `insightsAsOf(e, now)`
+ * equals the current active snapshot for the entity (the D4 invariant).
+ */
+export async function insightsAsOf(
+  entityType: RetrievalScope['entityType'],
+  entityId: string,
+  at: Date,
+  opts: AsOfOptions = {},
+): Promise<AsOfInsight[]> {
+  if (Number.isNaN(at.getTime())) {
+    throw new Error('insightsAsOf: `at` is an invalid Date');
+  }
+  if (!UUID_RE.test(entityId)) {
+    throw new Error(`insightsAsOf: entityId "${entityId}" is not a uuid`);
+  }
+  const load = opts.loadChanges ?? loadInsightChanges;
+  const rows = await load({ entityType, entityId }, at);
+  return replayInsightChanges(rows, opts);
+}


### PR DESCRIPTION
Closes #42 (D6). Stacked on #54 (D4 emit) — review only the last two commits.

"What was the POV on date X?" — `insightsAsOf(entityType, entityId, at)` reconstructs the
active insight set for an entity as of any past instant by replaying its append-only
`insight_changes` op-log up to the cutoff, generalizing the D4 invariant
`replay(insight_changes) == snapshot(insights)` from `now` to an arbitrary `at`.

### How
- **Loader** (raw SQL, D3 precedent — no Insight models in this repo yet): the entity's
  change rows with `created_at <= at` (tz-aware timestamptz comparison), scoped by joining
  through `insights` (change rows carry no entity columns), ordered by `(created_at, id)` —
  ids are uuidv7 on every write path, so the tie-break is deterministic AND time-ordered.
- **Fold** (`replayInsightChanges`, pure, exported for tests): ADD/UPDATE materialize
  `new_text`; NOOP is a no-op (tolerated present or absent); unknown ops warn and skip.
- **SUPERSEDE, grounded in what the apply actually writes**: the GUB apply persists ONE
  change row (`insight_id` = dropped target, `new_text` = replacement text) and mints the
  replacement insight in the same transaction, linked via `insights.created_by_op = change.id`
  — there is no paired ADD row. The loader recovers the replacement id through that link, so
  a single fold step drops the target and adds the replacement atomically: no cutoff can
  observe a transient hole.
- Malformed history degrades softly (warn + best effort) — a point-in-time read must not
  throw on one bad row years later.
- `snapshotActiveInsights(scope)` ships alongside as the invariant's right-hand side for
  eval / the D7 read path.

### Verification
- 20 hermetic tests (injected `loadChanges` seam — no prisma/network): replay at three
  historical dates over a synthetic add → update → update → supersede log matches
  hand-derived sets; inclusive cutoff boundary; supersede atomicity at its exact timestamp;
  `insightsAsOf(now)` == the declared current snapshot; same-timestamp id tie-break;
  degradation paths. Full suite 90/90 green; `tsc --noEmit` clean.
- Live check against the prod-copy DB (uncommitted script): 44/48 entities match the
  invariant exactly at `now`. The 4 mismatches are each one active insight with ZERO change
  rows (`created_by_op` NULL, all from one 2026-08-21 pre-op-log batch) — a dev-data gap the
  log cannot see, not a replay defect; worth deleting or ADD-backfilling separately.

Read-only module — no writes, no schema changes. The "POV on <date>" surface stays with D7.
